### PR TITLE
Update idofront and add all geary dependencies as api on geary-papermc

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,6 +12,12 @@ plugins {
 
 dependencies {
     api(project(":geary-papermc-tracking"))
+    api(gearyLibs.core)
+    api(gearyLibs.autoscan)
+    api(gearyLibs.prefabs)
+    api(gearyLibs.common.features)
+    api(gearyLibs.serialization)
+    api(gearyLibs.uuid)
 }
 
 allprojects {

--- a/geary-papermc-plugin/build.gradle.kts
+++ b/geary-papermc-plugin/build.gradle.kts
@@ -12,16 +12,11 @@ configurations {
         exclude(group = "org.jetbrains.kotlin")
         exclude(group = "org.jetbrains.kotlinx")
         exclude(group = "org.snakeyaml")
-        exclude(group = "com.charleskorn.kaml")
     }
 }
 
 dependencies {
-    implementation(project(":geary-papermc-tracking"))
-    implementation(gearyLibs.autoscan)
-    implementation(gearyLibs.prefabs)
-    implementation(gearyLibs.serialization)
-    implementation(gearyLibs.uuid)
+    implementation(project(":"))
 
     // Plugins
     compileOnly(myLibs.plugman)

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 kotlin.code.style=official
 group=com.mineinabyss
 version=0.23
-idofrontVersion=0.17.0
-gearyVersion=0.22.10
+idofrontVersion=0.18.0
+gearyVersion=0.22.11


### PR DESCRIPTION
Intended to make it easier for other plugins to depend on, as they can choose to have all of geary in one dependency or just tracking if needed.