### PR TITLE
Move startup to onLoad

### DIFF
--- a/geary-papermc-bridge/src/main/kotlin/com/mineinabyss/geary/papermc/bridge/PaperBridge.kt
+++ b/geary-papermc-bridge/src/main/kotlin/com/mineinabyss/geary/papermc/bridge/PaperBridge.kt
@@ -1,5 +1,6 @@
 package com.mineinabyss.geary.papermc.bridge
 
+import com.mineinabyss.geary.addons.GearyPhase
 import com.mineinabyss.geary.addons.dsl.GearyAddonWithDefault
 import com.mineinabyss.geary.modules.geary
 import com.mineinabyss.geary.papermc.bridge.actions.ExplosionSystem
@@ -18,12 +19,6 @@ import com.mineinabyss.idofront.plugin.listeners
 class PaperBridge {
     companion object : GearyAddonWithDefault<PaperBridge> {
         override fun PaperBridge.install() {
-            gearyPaper.plugin.listeners(
-                DeathBridge(),
-                ItemActionsBridge(),
-                MobActionsBridge(),
-            )
-
             geary.pipeline.addSystems(
                 CooldownDisplaySystem(),
                 ApplyAttribute(),
@@ -39,6 +34,14 @@ class PaperBridge {
                 TimeConditionChecker(),
                 ExplosionSystem(),
             )
+
+            geary.pipeline.runOnOrAfter(GearyPhase.ENABLE) {
+                gearyPaper.plugin.listeners(
+                    DeathBridge(),
+                    ItemActionsBridge(),
+                    MobActionsBridge(),
+                )
+            }
         }
 
         override fun default() = PaperBridge()

--- a/geary-papermc-plugin/src/main/kotlin/com/mineinabyss/geary/papermc/plugin/GearyPluginImpl.kt
+++ b/geary-papermc-plugin/src/main/kotlin/com/mineinabyss/geary/papermc/plugin/GearyPluginImpl.kt
@@ -2,6 +2,7 @@ package com.mineinabyss.geary.papermc.plugin
 
 import com.mineinabyss.geary.addons.GearyPhase.ENABLE
 import com.mineinabyss.geary.autoscan.autoscan
+import com.mineinabyss.geary.modules.ArchetypeEngineModule
 import com.mineinabyss.geary.modules.geary
 import com.mineinabyss.geary.papermc.GearyPaperConfigModule
 import com.mineinabyss.geary.papermc.GearyPlugin
@@ -34,7 +35,7 @@ import kotlin.io.path.name
 
 
 class GearyPluginImpl : GearyPlugin() {
-    override fun onEnable() {
+    override fun onLoad() {
         // Register DI
         val configModule = GearyProductionPaperConfigModule(this)
 
@@ -96,6 +97,10 @@ class GearyPluginImpl : GearyPlugin() {
 
         // Register commands
         GearyCommands()
+    }
+
+    override fun onEnable() {
+        ArchetypeEngineModule.start(DI.get<PaperEngineModule>())
     }
 
     override fun onDisable() {

--- a/geary-papermc-plugin/src/main/kotlin/com/mineinabyss/geary/papermc/plugin/GearyPluginImpl.kt
+++ b/geary-papermc-plugin/src/main/kotlin/com/mineinabyss/geary/papermc/plugin/GearyPluginImpl.kt
@@ -17,6 +17,7 @@ import com.mineinabyss.geary.papermc.tracking.entities.gearyMobs
 import com.mineinabyss.geary.papermc.tracking.entities.toGearyOrNull
 import com.mineinabyss.geary.papermc.tracking.items.ItemTracking
 import com.mineinabyss.geary.papermc.tracking.items.gearyItems
+import com.mineinabyss.geary.prefabs.PrefabKey
 import com.mineinabyss.geary.prefabs.prefabs
 import com.mineinabyss.geary.serialization.dsl.FileSystemAddon
 import com.mineinabyss.geary.serialization.dsl.serialization
@@ -24,11 +25,13 @@ import com.mineinabyss.geary.uuid.UUIDTracking
 import com.mineinabyss.idofront.di.DI
 import com.mineinabyss.idofront.messaging.logSuccess
 import com.mineinabyss.idofront.plugin.listeners
+import com.mineinabyss.idofront.serialization.SerializablePrefabItemService
 import com.mineinabyss.serialization.formats.YamlFormat
 import okio.FileSystem
 import okio.Path.Companion.toOkioPath
 import org.bukkit.entity.Player
 import org.bukkit.event.Listener
+import org.bukkit.inventory.ItemStack
 import kotlin.io.path.isDirectory
 import kotlin.io.path.listDirectoryEntries
 import kotlin.io.path.name
@@ -94,6 +97,15 @@ class GearyPluginImpl : GearyPlugin() {
                 logSuccess("Loaded item types: ${gearyItems.prefabs.getKeys().joinToString()}")
             }
         }
+
+
+        DI.add<SerializablePrefabItemService>(
+            object : SerializablePrefabItemService {
+                override fun encodeFromPrefab(item: ItemStack, prefabName: String) {
+                    val result = gearyItems.createItem(PrefabKey.of(prefabName), item)
+                    require(result != null) { "Failed to create serializable ItemStack from $prefabName, does the prefab exist and have a geary:set.item component?" }
+                }
+            })
 
         // Register commands
         GearyCommands()

--- a/geary-papermc-plugin/src/main/kotlin/com/mineinabyss/geary/papermc/plugin/PaperEngineModule.kt
+++ b/geary-papermc-plugin/src/main/kotlin/com/mineinabyss/geary/papermc/plugin/PaperEngineModule.kt
@@ -2,14 +2,13 @@ package com.mineinabyss.geary.papermc.plugin
 
 import co.touchlab.kermit.Logger
 import co.touchlab.kermit.StaticConfig
-import com.github.shynixn.mccoroutine.bukkit.launch
 import com.mineinabyss.geary.engine.archetypes.ArchetypeEngine
 import com.mineinabyss.geary.modules.ArchetypeEngineModule
 import com.mineinabyss.geary.modules.GearyModuleProvider
 import com.mineinabyss.geary.papermc.GearyPlugin
 import com.mineinabyss.geary.papermc.gearyPaper
+import com.mineinabyss.idofront.di.DI
 import com.mineinabyss.idofront.time.ticks
-import kotlinx.coroutines.delay
 
 class PaperEngineModule(val plugin: GearyPlugin) :
     ArchetypeEngineModule(tickDuration = 1.ticks) {
@@ -18,10 +17,7 @@ class PaperEngineModule(val plugin: GearyPlugin) :
 
     companion object: GearyModuleProvider<PaperEngineModule> {
         override fun start(module: PaperEngineModule) {
-            module.plugin.launch {
-                delay(1.ticks) // Waits until first tick has complete (all plugins loaded)
-                ArchetypeEngineModule.start(module)
-            }
+            DI.add<PaperEngineModule>(module)
         }
 
         override fun init(module: PaperEngineModule) {

--- a/geary-papermc-tracking/src/main/kotlin/com/mineinabyss/geary/papermc/tracking/entities/EntityTracking.kt
+++ b/geary-papermc-tracking/src/main/kotlin/com/mineinabyss/geary/papermc/tracking/entities/EntityTracking.kt
@@ -1,5 +1,6 @@
 package com.mineinabyss.geary.papermc.tracking.entities
 
+import com.mineinabyss.geary.addons.GearyPhase
 import com.mineinabyss.geary.addons.dsl.GearyAddonWithDefault
 import com.mineinabyss.geary.datatypes.ComponentId
 import com.mineinabyss.geary.helpers.componentId
@@ -26,13 +27,15 @@ interface EntityTracking {
         }
 
         override fun EntityTracking.install() {
-            gearyPaper.plugin.listeners(EntityWorldEventTracker())
             geary.pipeline.addSystems(
                 TrackOnSetBukkitComponent(),
                 UntrackOnRemoveBukkitComponent(),
                 AttemptSpawnListener(),
                 AttemptSpawnMythicMob()
             )
+            geary.pipeline.runOnOrAfter(GearyPhase.ENABLE) {
+                gearyPaper.plugin.listeners(EntityWorldEventTracker())
+            }
         }
     }
 }

--- a/geary-papermc-tracking/src/main/kotlin/com/mineinabyss/geary/papermc/tracking/items/ItemTracking.kt
+++ b/geary-papermc-tracking/src/main/kotlin/com/mineinabyss/geary/papermc/tracking/items/ItemTracking.kt
@@ -1,5 +1,6 @@
 package com.mineinabyss.geary.papermc.tracking.items
 
+import com.mineinabyss.geary.addons.GearyPhase
 import com.mineinabyss.geary.addons.dsl.GearyAddonWithDefault
 import com.mineinabyss.geary.datatypes.GearyEntity
 import com.mineinabyss.geary.modules.geary
@@ -36,16 +37,19 @@ interface ItemTracking {
         override fun default(): ItemTracking = NMSBackedItemTracking()
 
         override fun ItemTracking.install() {
-            gearyPaper.plugin.listeners(
-                loginListener,
-                SetItemIgnoredPropertyListener(),
-                MythicMobDropSystem()
-            )
             geary.pipeline.addSystems(
                 InventoryTrackerSystem(),
                 CustomModelDataToPrefabTracker(),
                 SetItemMigrationSystem()
             )
+
+            geary.pipeline.runOnOrAfter(GearyPhase.ENABLE) {
+                gearyPaper.plugin.listeners(
+                    loginListener,
+                    SetItemIgnoredPropertyListener(),
+                    MythicMobDropSystem()
+                )
+            }
         }
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 kotlin.code.style=official
 group=com.mineinabyss
-version=0.26
+version=0.27
 idofrontVersion=0.20.1
 gearyVersion=0.23-SNAPSHOT

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 kotlin.code.style=official
 group=com.mineinabyss
 version=0.27
-idofrontVersion=0.20.1
+idofrontVersion=0.20.6
 gearyVersion=0.23-SNAPSHOT


### PR DESCRIPTION
Dependent plugins must move their `geary` declaration to `onLoad` and assume everything has been loaded in `onEnabled`. This is to avoid delaying by one tick and keeping the loading process cleaner.