### PR TITLE
Tracking fixes, entity type, MM conversion

### DIFF
--- a/geary-papermc-datastore/src/main/kotlin/com/mineinabyss/geary/papermc/datastore/DataStore.kt
+++ b/geary-papermc-datastore/src/main/kotlin/com/mineinabyss/geary/papermc/datastore/DataStore.kt
@@ -147,7 +147,7 @@ fun PersistentDataContainer.decodeComponents(): DecodedEntityData =
 
 /** Verifies a [PersistentDataContainer] has a tag identifying it as containing Geary components. */
 var PersistentDataContainer.hasComponentsEncoded: Boolean
-    get() = has(COMPONENTS_KEY, PersistentDataType.BYTE)
+    get() = has(COMPONENTS_KEY, PersistentDataType.BYTE) || has(PREFABS_KEY, PersistentDataType.BYTE_ARRAY)
     set(value) {
         when {
             value -> if (!hasComponentsEncoded) set(COMPONENTS_KEY, PersistentDataType.BYTE, 1)

--- a/geary-papermc-plugin/src/main/kotlin/com/mineinabyss/geary/papermc/plugin/GearyPluginImpl.kt
+++ b/geary-papermc-plugin/src/main/kotlin/com/mineinabyss/geary/papermc/plugin/GearyPluginImpl.kt
@@ -9,6 +9,7 @@ import com.mineinabyss.geary.papermc.GearyPlugin
 import com.mineinabyss.geary.papermc.GearyProductionPaperConfigModule
 import com.mineinabyss.geary.papermc.bridge.PaperBridge
 import com.mineinabyss.geary.papermc.configlang.ConfigLang
+import com.mineinabyss.geary.papermc.datastore.encodeComponentsTo
 import com.mineinabyss.geary.papermc.datastore.withUUIDSerializer
 import com.mineinabyss.geary.papermc.tracking.blocks.BlockTracking
 import com.mineinabyss.geary.papermc.tracking.blocks.gearyBlocks
@@ -29,7 +30,6 @@ import com.mineinabyss.idofront.serialization.SerializablePrefabItemService
 import com.mineinabyss.serialization.formats.YamlFormat
 import okio.FileSystem
 import okio.Path.Companion.toOkioPath
-import org.bukkit.entity.Player
 import org.bukkit.event.Listener
 import org.bukkit.inventory.ItemStack
 import kotlin.io.path.isDirectory
@@ -118,8 +118,9 @@ class GearyPluginImpl : GearyPlugin() {
     override fun onDisable() {
         server.worlds.forEach { world ->
             world.entities.forEach entities@{ entity ->
-                if (entity is Player) return@entities
-                entity.toGearyOrNull()?.removeEntity()
+                val gearyEntity = entity.toGearyOrNull() ?: return@entities
+                gearyEntity.encodeComponentsTo(entity)
+                gearyEntity.removeEntity()
             }
         }
         server.scheduler.cancelTasks(this)

--- a/geary-papermc-tracking/build.gradle.kts
+++ b/geary-papermc-tracking/build.gradle.kts
@@ -14,6 +14,7 @@ repositories {
 dependencies {
     compileOnly(libs.minecraft.plugin.mythic.dist)
     compileOnly(libs.idofront.nms)
+    compileOnly(libs.minecraft.mccoroutine)
     implementation(gearyLibs.uuid)
     api(project(":geary-papermc-datastore"))
     api(project(":geary-papermc-core"))

--- a/geary-papermc-tracking/src/main/kotlin/com/mineinabyss/geary/papermc/tracking/entities/BukkitEntity2Geary.kt
+++ b/geary-papermc-tracking/src/main/kotlin/com/mineinabyss/geary/papermc/tracking/entities/BukkitEntity2Geary.kt
@@ -3,6 +3,8 @@ package com.mineinabyss.geary.papermc.tracking.entities
 import com.mineinabyss.geary.datatypes.GearyEntity
 import com.mineinabyss.geary.helpers.entity
 import com.mineinabyss.geary.helpers.toGeary
+import com.mineinabyss.geary.papermc.tracking.entities.components.AddedToWorld
+import com.mineinabyss.geary.papermc.tracking.entities.events.GearyEntityAddToWorldEvent
 import com.mineinabyss.idofront.typealiases.BukkitEntity
 import it.unimi.dsi.fastutil.ints.Int2LongOpenHashMap
 import org.spigotmc.AsyncCatcher
@@ -30,7 +32,10 @@ class BukkitEntity2Geary(val forceMainThread: Boolean = true) {
     fun getOrCreate(bukkit: BukkitEntity): GearyEntity {
         return get(bukkit) ?: run {
             if (forceMainThread) AsyncCatcher.catchOp("Async geary entity creation for $bukkit")
-            entity { set(bukkit) }
+            entity { set(bukkit) }.also {
+                it.add<AddedToWorld>()
+                GearyEntityAddToWorldEvent(it, bukkit).callEvent()
+            }
         }
     }
 }

--- a/geary-papermc-tracking/src/main/kotlin/com/mineinabyss/geary/papermc/tracking/entities/EntityTracking.kt
+++ b/geary-papermc-tracking/src/main/kotlin/com/mineinabyss/geary/papermc/tracking/entities/EntityTracking.kt
@@ -7,10 +7,17 @@ import com.mineinabyss.geary.helpers.componentId
 import com.mineinabyss.geary.modules.geary
 import com.mineinabyss.geary.papermc.gearyPaper
 import com.mineinabyss.geary.papermc.tracking.entities.helpers.GearyMobPrefabQuery
-import com.mineinabyss.geary.papermc.tracking.entities.systems.*
+import com.mineinabyss.geary.papermc.tracking.entities.systems.EntityWorldEventTracker
+import com.mineinabyss.geary.papermc.tracking.entities.systems.TrackOnSetBukkitComponent
+import com.mineinabyss.geary.papermc.tracking.entities.systems.UntrackOnRemoveBukkitComponent
+import com.mineinabyss.geary.papermc.tracking.entities.systems.attemptspawn.AttemptSpawnListener
+import com.mineinabyss.geary.papermc.tracking.entities.systems.attemptspawn.AttemptSpawnMythicMob
+import com.mineinabyss.geary.papermc.tracking.entities.systems.updatemobtype.ConvertEntityTypesListener
+import com.mineinabyss.geary.papermc.tracking.entities.systems.updatemobtype.ConvertToMythicMobListener
 import com.mineinabyss.idofront.di.DI
 import com.mineinabyss.idofront.plugin.listeners
 import com.mineinabyss.idofront.typealiases.BukkitEntity
+import org.bukkit.Bukkit
 
 val gearyMobs by DI.observe<EntityTracking>()
 
@@ -31,10 +38,22 @@ interface EntityTracking {
                 TrackOnSetBukkitComponent(),
                 UntrackOnRemoveBukkitComponent(),
                 AttemptSpawnListener(),
-                AttemptSpawnMythicMob()
             )
             geary.pipeline.runOnOrAfter(GearyPhase.ENABLE) {
-                gearyPaper.plugin.listeners(EntityWorldEventTracker())
+                gearyPaper.plugin.listeners(
+                    EntityWorldEventTracker(),
+                    ConvertEntityTypesListener(),
+                )
+
+                if (Bukkit.getPluginManager().plugins.any { it.name == "MythicMobs" }) {
+                    geary.pipeline.addSystems(
+                        AttemptSpawnMythicMob(),
+                    )
+
+                    gearyPaper.plugin.listeners(
+                        ConvertToMythicMobListener(),
+                    )
+                }
             }
         }
     }

--- a/geary-papermc-tracking/src/main/kotlin/com/mineinabyss/geary/papermc/tracking/entities/events/GearyEntityAddToWorldEvent.kt
+++ b/geary-papermc-tracking/src/main/kotlin/com/mineinabyss/geary/papermc/tracking/entities/events/GearyEntityAddToWorldEvent.kt
@@ -1,0 +1,28 @@
+package com.mineinabyss.geary.papermc.tracking.entities.events
+
+import com.mineinabyss.geary.datatypes.GearyEntity
+import com.mineinabyss.idofront.typealiases.BukkitEntity
+import org.bukkit.event.Event
+import org.bukkit.event.HandlerList
+
+
+/**
+ * Called when a bukkit entity is added to the world and registered with Geary.
+ *
+ * Will avoid multiple calls like the Paper event currently does
+ */
+class GearyEntityAddToWorldEvent(
+    val gearyEntity: GearyEntity,
+    val entity: BukkitEntity,
+) : Event() {
+    companion object {
+        @JvmStatic
+        private val HANDLER_LIST = HandlerList()
+
+        @JvmStatic
+        fun getHandlerList() = HANDLER_LIST
+    }
+
+    override fun getHandlers() = HANDLER_LIST
+
+}

--- a/geary-papermc-tracking/src/main/kotlin/com/mineinabyss/geary/papermc/tracking/entities/helpers/Helpers.kt
+++ b/geary-papermc-tracking/src/main/kotlin/com/mineinabyss/geary/papermc/tracking/entities/helpers/Helpers.kt
@@ -2,12 +2,14 @@ package com.mineinabyss.geary.papermc.tracking.entities.helpers
 
 import com.mineinabyss.geary.datatypes.GearyEntity
 import com.mineinabyss.geary.helpers.entity
+import com.mineinabyss.geary.papermc.datastore.loadComponentsFrom
 import com.mineinabyss.geary.papermc.tracking.entities.components.AttemptSpawn
 import com.mineinabyss.geary.prefabs.PrefabKey
 import com.mineinabyss.geary.prefabs.helpers.addPrefab
 import com.mineinabyss.geary.prefabs.prefabs
 import com.mineinabyss.idofront.typealiases.BukkitEntity
 import org.bukkit.Location
+import org.bukkit.persistence.PersistentDataContainer
 
 
 fun Location.spawnFromPrefab(prefab: PrefabKey): Result<BukkitEntity> {
@@ -15,9 +17,10 @@ fun Location.spawnFromPrefab(prefab: PrefabKey): Result<BukkitEntity> {
     return spawnFromPrefab(entity)
 }
 
-fun Location.spawnFromPrefab(prefab: GearyEntity): Result<BukkitEntity> {
+fun Location.spawnFromPrefab(prefab: GearyEntity, existingPDC: PersistentDataContainer? = null): Result<BukkitEntity> {
     return runCatching {
         entity {
+            if (existingPDC != null) loadComponentsFrom(existingPDC)
             addPrefab(prefab)
             callEvent(AttemptSpawn(this@spawnFromPrefab))
         }.get<BukkitEntity>() ?: error("Entity was not created when spawning from prefab")

--- a/geary-papermc-tracking/src/main/kotlin/com/mineinabyss/geary/papermc/tracking/entities/systems/UntrackOnRemoveBukkitComponent.kt
+++ b/geary-papermc-tracking/src/main/kotlin/com/mineinabyss/geary/papermc/tracking/entities/systems/UntrackOnRemoveBukkitComponent.kt
@@ -3,7 +3,6 @@ package com.mineinabyss.geary.papermc.tracking.entities.systems
 import com.mineinabyss.geary.annotations.optin.UnsafeAccessors
 import com.mineinabyss.geary.components.events.EntityRemoved
 import com.mineinabyss.geary.datatypes.family.family
-import com.mineinabyss.geary.papermc.datastore.encodeComponentsTo
 import com.mineinabyss.geary.papermc.tracking.entities.gearyMobs
 import com.mineinabyss.geary.systems.GearyListener
 import com.mineinabyss.geary.systems.accessors.Pointers
@@ -16,6 +15,5 @@ class UntrackOnRemoveBukkitComponent : GearyListener() {
     @OptIn(UnsafeAccessors::class)
     override fun Pointers.handle() {
         gearyMobs.bukkit2Geary.remove(bukkit.entityId)
-        target.entity.encodeComponentsTo(bukkit)
     }
 }

--- a/geary-papermc-tracking/src/main/kotlin/com/mineinabyss/geary/papermc/tracking/entities/systems/attemptspawn/AttemptSpawnListener.kt
+++ b/geary-papermc-tracking/src/main/kotlin/com/mineinabyss/geary/papermc/tracking/entities/systems/attemptspawn/AttemptSpawnListener.kt
@@ -1,4 +1,4 @@
-package com.mineinabyss.geary.papermc.tracking.entities.systems
+package com.mineinabyss.geary.papermc.tracking.entities.systems.attemptspawn
 
 import com.mineinabyss.geary.annotations.optin.UnsafeAccessors
 import com.mineinabyss.geary.datatypes.family.family

--- a/geary-papermc-tracking/src/main/kotlin/com/mineinabyss/geary/papermc/tracking/entities/systems/attemptspawn/AttemptSpawnMythicMob.kt
+++ b/geary-papermc-tracking/src/main/kotlin/com/mineinabyss/geary/papermc/tracking/entities/systems/attemptspawn/AttemptSpawnMythicMob.kt
@@ -1,4 +1,4 @@
-package com.mineinabyss.geary.papermc.tracking.entities.systems
+package com.mineinabyss.geary.papermc.tracking.entities.systems.attemptspawn
 
 import com.mineinabyss.geary.annotations.optin.UnsafeAccessors
 import com.mineinabyss.geary.datatypes.family.family
@@ -10,6 +10,7 @@ import com.mineinabyss.idofront.typealiases.BukkitEntity
 import io.lumine.mythic.api.mobs.entities.SpawnReason
 import io.lumine.mythic.bukkit.BukkitAdapter
 import io.lumine.mythic.bukkit.MythicBukkit
+import kotlin.jvm.optionals.getOrNull
 
 
 class AttemptSpawnMythicMob : GearyListener() {
@@ -22,9 +23,10 @@ class AttemptSpawnMythicMob : GearyListener() {
 
     @OptIn(UnsafeAccessors::class)
     override fun Pointers.handle() {
-        val mythicMob = MythicBukkit.inst().mobManager.getMythicMob(mobType.id).orElse(null) ?: return
+        val mythicMob = MythicBukkit.inst().mobManager.getMythicMob(mobType.id).getOrNull() ?: return
         mythicMob.spawn(BukkitAdapter.adapt(attemptSpawn.location), 1.0, SpawnReason.NATURAL) { mob ->
             target.entity.set(mob)
+            target.entity.set(mythicMob)
         }
     }
 }

--- a/geary-papermc-tracking/src/main/kotlin/com/mineinabyss/geary/papermc/tracking/entities/systems/updatemobtype/ConvertEntityTypesListener.kt
+++ b/geary-papermc-tracking/src/main/kotlin/com/mineinabyss/geary/papermc/tracking/entities/systems/updatemobtype/ConvertEntityTypesListener.kt
@@ -1,0 +1,18 @@
+package com.mineinabyss.geary.papermc.tracking.entities.systems.updatemobtype
+
+import com.mineinabyss.geary.papermc.tracking.entities.components.SetEntityType
+import com.mineinabyss.geary.papermc.tracking.entities.events.GearyEntityAddToWorldEvent
+import com.mineinabyss.idofront.nms.aliases.toNMS
+import org.bukkit.event.EventHandler
+import org.bukkit.event.Listener
+
+class ConvertEntityTypesListener : Listener {
+    @EventHandler
+    fun GearyEntityAddToWorldEvent.onAdd() {
+        val type = gearyEntity.get<SetEntityType>() ?: return
+
+        if (entity.toNMS().type != type.entityTypeFromRegistry) {
+            UpdateMob.scheduleRecreation(entity, gearyEntity)
+        }
+    }
+}

--- a/geary-papermc-tracking/src/main/kotlin/com/mineinabyss/geary/papermc/tracking/entities/systems/updatemobtype/ConvertToMythicMobListener.kt
+++ b/geary-papermc-tracking/src/main/kotlin/com/mineinabyss/geary/papermc/tracking/entities/systems/updatemobtype/ConvertToMythicMobListener.kt
@@ -1,0 +1,24 @@
+package com.mineinabyss.geary.papermc.tracking.entities.systems.updatemobtype
+
+import com.mineinabyss.geary.papermc.tracking.entities.components.SetMythicMob
+import com.mineinabyss.geary.papermc.tracking.entities.events.GearyEntityAddToWorldEvent
+import io.lumine.mythic.api.mobs.MythicMob
+import io.lumine.mythic.bukkit.MythicBukkit
+import io.lumine.mythic.core.constants.MobKeys
+import org.bukkit.event.EventHandler
+import org.bukkit.event.Listener
+
+class ConvertToMythicMobListener : Listener {
+    @EventHandler
+    fun GearyEntityAddToWorldEvent.onAdd() {
+        val mm = MythicBukkit.inst()
+        // If MM already encoded or loaded, we let it handle things itself
+        if (entity.persistentDataContainer.has(MobKeys.TYPE)) return
+        if (mm.mobManager.mobRegistry.isActiveMob(entity.uniqueId)) return
+
+        if (!gearyEntity.has<SetMythicMob>()) return
+        if (gearyEntity.has<MythicMob>()) return
+
+        UpdateMob.scheduleRecreation(entity, gearyEntity)
+    }
+}

--- a/geary-papermc-tracking/src/main/kotlin/com/mineinabyss/geary/papermc/tracking/entities/systems/updatemobtype/UpdateMob.kt
+++ b/geary-papermc-tracking/src/main/kotlin/com/mineinabyss/geary/papermc/tracking/entities/systems/updatemobtype/UpdateMob.kt
@@ -1,0 +1,23 @@
+package com.mineinabyss.geary.papermc.tracking.entities.systems.updatemobtype
+
+import com.mineinabyss.geary.datatypes.GearyEntity
+import com.mineinabyss.geary.papermc.gearyPaper
+import com.mineinabyss.geary.papermc.tracking.entities.helpers.spawnFromPrefab
+import com.mineinabyss.geary.prefabs.helpers.prefabs
+import com.mineinabyss.idofront.typealiases.BukkitEntity
+import org.bukkit.Bukkit
+
+object UpdateMob {
+    fun scheduleRecreation(entity: BukkitEntity, gearyEntity: GearyEntity) {
+        val loc = entity.location
+        val prefab = gearyEntity.prefabs.first()
+
+        Bukkit.getScheduler().scheduleSyncDelayedTask(gearyPaper.plugin, {
+            entity.remove()
+        }, 1)
+        Bukkit.getScheduler().scheduleSyncDelayedTask(gearyPaper.plugin, {
+            loc.spawnFromPrefab(prefab, entity.persistentDataContainer)
+                .getOrThrow()
+        }, 10)
+    }
+}

--- a/geary-tests/src/test/kotlin/com/mineinabyss/geary/papermc/tracking/entities/EntityTrackingTests.kt
+++ b/geary-tests/src/test/kotlin/com/mineinabyss/geary/papermc/tracking/entities/EntityTrackingTests.kt
@@ -1,7 +1,6 @@
 package com.mineinabyss.geary.papermc.tracking.entities
 
 import com.destroystokyo.paper.event.entity.EntityAddToWorldEvent
-import com.destroystokyo.paper.event.entity.EntityRemoveFromWorldEvent
 import com.mineinabyss.geary.datatypes.GearyEntity
 import com.mineinabyss.geary.modules.TestEngineModule
 import com.mineinabyss.geary.modules.geary
@@ -11,6 +10,7 @@ import com.mineinabyss.geary.papermc.helpers.SomeData
 import com.mineinabyss.geary.papermc.helpers.TestEntityTracking
 import com.mineinabyss.geary.papermc.helpers.withTestSerializers
 import com.mineinabyss.geary.serialization.dsl.serialization
+import com.mineinabyss.geary.uuid.UUIDTracking
 import com.mineinabyss.idofront.typealiases.BukkitEntity
 import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.nulls.shouldNotBeNull
@@ -28,6 +28,7 @@ class EntityTrackingTests: MockedServerTest() {
                 withTestSerializers()
             }
             install(TestEntityTracking)
+            install(UUIDTracking)
         }
         geary.pipeline.runStartupTasks()
     }
@@ -100,18 +101,19 @@ class EntityTrackingTests: MockedServerTest() {
             )
         }
 
-        @Test
-        fun `should persist components on entities`() {
-            val pig = world.spawn(world.spawnLocation, Pig::class.java)
-            EntityAddToWorldEvent(pig).callEvent()
-
-            testPersistence(
-                pig.toGeary(),
-                pig.persistentDataContainer
-            ) {
-                pig.remove()
-                EntityRemoveFromWorldEvent(pig).callEvent()
-            }
-        }
+        //TODO this test wouldn't reflect data actually being written to NBT, maybe the event calls too late to save!
+//        @Test
+//        fun `should persist components on entities`() {
+//            val pig = world.spawn(world.spawnLocation, Pig::class.java)
+//            EntityAddToWorldEvent(pig).callEvent()
+//
+//            testPersistence(
+//                pig.toGeary(),
+//                pig.persistentDataContainer
+//            ) {
+//                pig.remove()
+//                EntityRemoveFromWorldEvent(pig).callEvent()
+//            }
+//        }
     }
 }

--- a/geary-tests/src/test/kotlin/com/mineinabyss/geary/papermc/tracking/entities/EntityTrackingTests.kt
+++ b/geary-tests/src/test/kotlin/com/mineinabyss/geary/papermc/tracking/entities/EntityTrackingTests.kt
@@ -17,6 +17,7 @@ import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
 import org.bukkit.entity.Pig
 import org.bukkit.entity.Player
+import org.bukkit.event.world.EntitiesUnloadEvent
 import org.bukkit.persistence.PersistentDataContainer
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -91,7 +92,7 @@ class EntityTrackingTests: MockedServerTest() {
         }
 
         @Test
-        fun `should persist components on player disconnect`() {
+        fun `should persist components when player disconnects`() {
             val player = server.addPlayer()
 
             testPersistence(
@@ -101,19 +102,17 @@ class EntityTrackingTests: MockedServerTest() {
             )
         }
 
-        //TODO this test wouldn't reflect data actually being written to NBT, maybe the event calls too late to save!
-//        @Test
-//        fun `should persist components on entities`() {
-//            val pig = world.spawn(world.spawnLocation, Pig::class.java)
-//            EntityAddToWorldEvent(pig).callEvent()
-//
-//            testPersistence(
-//                pig.toGeary(),
-//                pig.persistentDataContainer
-//            ) {
-//                pig.remove()
-//                EntityRemoveFromWorldEvent(pig).callEvent()
-//            }
-//        }
+        @Test
+        fun `should persist components on entities when chunk unloaded`() {
+            val pig = world.spawn(world.spawnLocation, Pig::class.java)
+            EntityAddToWorldEvent(pig).callEvent()
+
+            testPersistence(
+                pig.toGeary(),
+                pig.persistentDataContainer
+            ) {
+                EntitiesUnloadEvent(pig.location.chunk, listOf(pig)).callEvent()
+            }
+        }
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 kotlin.code.style=official
 group=com.mineinabyss
-version=0.27
+version=0.28
 idofrontVersion=0.20.14
-gearyVersion=0.24-SNAPSHOT
+gearyVersion=0.24.0


### PR DESCRIPTION
- Handle bug in paper load/unload/load events fired when loading entity in chunk, add GearyEntityAddToWorldEvent that only fires once
- Change component encoding to happen on chunk unload, not entity remove now that the remove is delayed to avoid above paper bug
- Encode on component plugin disable
- Recreate entity when swapping to set mythicmob component, or changing types in set entitytype