### PR TITLE
fix: issues with dropping items

### DIFF
--- a/geary-papermc-bridge/src/main/kotlin/com/mineinabyss/geary/papermc/bridge/events/items/ItemRemovedBridge.kt
+++ b/geary-papermc-bridge/src/main/kotlin/com/mineinabyss/geary/papermc/bridge/events/items/ItemRemovedBridge.kt
@@ -5,9 +5,13 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import org.bukkit.event.EventHandler
 import org.bukkit.event.Listener
+import org.bukkit.event.inventory.ClickType
+import org.bukkit.event.inventory.InventoryAction
+import org.bukkit.event.inventory.InventoryClickEvent
 import org.bukkit.event.player.PlayerDropItemEvent
 import org.bukkit.event.player.PlayerItemBreakEvent
 import org.bukkit.event.player.PlayerItemConsumeEvent
+import org.bukkit.inventory.PlayerInventory
 
 @Serializable
 @SerialName("geary:on_item_consumed")
@@ -35,8 +39,30 @@ class ItemRemovedBridge : Listener {
     }
 
     @EventHandler(ignoreCancelled = true)
-    fun PlayerDropItemEvent.emitOnItemDrop() {
-        val droppedItem = player.inventory.toGeary()?.find(itemDrop.itemStack) ?: return
+    fun InventoryClickEvent.emitOnItemDrop() {
+        // InventoryCreativeEvent handles CREATIVE-mode
+        if (click == ClickType.CREATIVE) return
+        // Skip any clicks not outside the screen or players inventory
+        if (clickedInventory != null && clickedInventory !is PlayerInventory) return
+
+        val droppedItem = when (action) {
+            // dropped by clicking outside of inventory
+            InventoryAction.DROP_ALL_CURSOR, InventoryAction.DROP_ONE_CURSOR ->
+                whoClicked.inventory.toGeary()?.itemOnCursor ?: return
+            // dropped by pressing Q while hovering a slot
+            InventoryAction.DROP_ALL_SLOT, InventoryAction.DROP_ONE_SLOT ->
+                whoClicked.inventory.toGeary()?.get(slot) ?: return
+            else -> return
+        }
         droppedItem.emit<OnItemDrop>()
+    }
+
+    @EventHandler(ignoreCancelled = true)
+    fun PlayerDropItemEvent.emitOnItemDrop() {
+        // The dropped itemstack will never be found in the inventory
+        // If one drops a single item, it would look for an itemstack with size 1
+        // if one drops the entire stack then it would not exist in the inventory
+        //val droppedItem = player.inventory.toGeary()?.find(itemDrop.itemStack) ?: return
+        //droppedItem.emit<OnItemDrop>()
     }
 }

--- a/geary-papermc-tracking/src/main/kotlin/com/mineinabyss/geary/papermc/tracking/items/inventory/NMSInventoryCacheWrapper.kt
+++ b/geary-papermc-tracking/src/main/kotlin/com/mineinabyss/geary/papermc/tracking/items/inventory/NMSInventoryCacheWrapper.kt
@@ -28,7 +28,9 @@ class NMSInventoryCacheWrapper(
                 inventory.holder?.itemOnCursor?.toNMS()
             ) { toArray(inventory.toNMS()) }
         } else {
-            cache.getOrUpdate(slot, inventory.toNMS().getItem(slot)) { toArray(inventory.toNMS()) }
+            runCatching { inventory.toNMS().getItem(slot) }.getOrNull()?.let { item ->
+                cache.getOrUpdate(slot, item) { toArray(inventory.toNMS()) }
+            }
         }
     }
 


### PR DESCRIPTION
There really is no perfect way to handle it
InventoryClickEvent lets us handle most things when dropped from the Inventory screen
Items dropped from hand are not possiible really to get
the issue is that the PlayerDropItemEvent fires **after** the player has dropped the item
Thus the GearyInventory#find returns -1 when attempting to index for the itemstack
It is also flawed as if you drop a single item, the itemstack would not be found in the inventory anyway

The best one can do is handle it via the itemDrop entity as a geary-entity though i doubt thats the idea
```kt
@EventHandler(ignoreCancelled = true)
fun PlayerDropItemEvent.emitOnItemDrop() {
    itemDrop.toGearyOrNull()?.emit<OnItemDrop>()
}
```