### PR TITLE
feat: le hyper optimize spawningu

### DIFF
--- a/geary-papermc-spawning/src/main/kotlin/com/mineinabyss/geary/papermc/spawning/choosing/SpawnChooser.kt
+++ b/geary-papermc-spawning/src/main/kotlin/com/mineinabyss/geary/papermc/spawning/choosing/SpawnChooser.kt
@@ -13,18 +13,15 @@ class SpawnChooser(
     val wg: WorldGuardSpawning,
     val caps: MobCaps,
 ) {
-    fun getAllowedSpawnsNear(
-        location: Location,
-        position: SpawnPosition,
-    ): List<SpawnEntry>? {
-        // Get spawns from regions
+    fun getAllowedSpawnsNear(location: Location, position: SpawnPosition): ObjectArrayList<SpawnEntry>? {
         val regions = wg.getRegionsAt(location)
         val spawnsInRegion = wg.getSpawnsForRegions(regions).takeUnless { it.isEmpty() } ?: return null
 
-        // Check mob caps
-        val allowedSpawns = caps.filterAllowedAt(location, spawnsInRegion.filterTo(ObjectArrayList()) { it.position == position })
+        // a predicate for the filter
+        val positionPredicate = { spawn: SpawnEntry -> spawn.position == position }
 
-        return allowedSpawns
+        // allow MobCaps to directly handle the filter predicate
+        return caps.filterAllowedAt(location, spawnsInRegion, positionPredicate)
     }
 
     fun chooseAllowedSpawnNear(location: Location, position: SpawnPosition): SpawnEntry? {

--- a/geary-papermc-spawning/src/main/kotlin/com/mineinabyss/geary/papermc/spawning/choosing/SpawnChooser.kt
+++ b/geary-papermc-spawning/src/main/kotlin/com/mineinabyss/geary/papermc/spawning/choosing/SpawnChooser.kt
@@ -5,15 +5,13 @@ import com.mineinabyss.geary.papermc.spawning.choosing.worldguard.WorldGuardSpaw
 import com.mineinabyss.geary.papermc.spawning.config.SpawnEntry
 import com.mineinabyss.geary.papermc.spawning.config.SpawnPosition
 import com.mineinabyss.geary.papermc.spawning.helpers.WeightedList
-import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap
-import it.unimi.dsi.fastutil.objects.ObjectArrayList
 import org.bukkit.Location
 
 class SpawnChooser(
     val wg: WorldGuardSpawning,
     val caps: MobCaps,
 ) {
-    fun getAllowedSpawnsNear(location: Location, position: SpawnPosition): ObjectArrayList<SpawnEntry>? {
+    fun getAllowedSpawnsNear(location: Location, position: SpawnPosition): List<SpawnEntry>? {
         val regions = wg.getRegionsAt(location)
         val spawnsInRegion = wg.getSpawnsForRegions(regions).takeUnless { it.isEmpty() } ?: return null
 
@@ -26,6 +24,6 @@ class SpawnChooser(
 
     fun chooseAllowedSpawnNear(location: Location, position: SpawnPosition): SpawnEntry? {
         val allowedSpawns = getAllowedSpawnsNear(location, position)?.takeUnless { it.isEmpty() } ?: return null
-        return WeightedList(allowedSpawns.associateWithTo(Object2ObjectOpenHashMap()) { it.priority }).roll()
+        return WeightedList(allowedSpawns.associateWith { it.priority }).roll()
     }
 }

--- a/geary-papermc-spawning/src/main/kotlin/com/mineinabyss/geary/papermc/spawning/choosing/SpawnChooser.kt
+++ b/geary-papermc-spawning/src/main/kotlin/com/mineinabyss/geary/papermc/spawning/choosing/SpawnChooser.kt
@@ -5,6 +5,8 @@ import com.mineinabyss.geary.papermc.spawning.choosing.worldguard.WorldGuardSpaw
 import com.mineinabyss.geary.papermc.spawning.config.SpawnEntry
 import com.mineinabyss.geary.papermc.spawning.config.SpawnPosition
 import com.mineinabyss.geary.papermc.spawning.helpers.WeightedList
+import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap
+import it.unimi.dsi.fastutil.objects.ObjectArrayList
 import org.bukkit.Location
 
 class SpawnChooser(
@@ -14,22 +16,19 @@ class SpawnChooser(
     fun getAllowedSpawnsNear(
         location: Location,
         position: SpawnPosition,
-    ): List<SpawnEntry> {
+    ): List<SpawnEntry>? {
         // Get spawns from regions
         val regions = wg.getRegionsAt(location)
-        val spawnsInRegion = wg.getSpawnsForRegions(regions)
-        if (spawnsInRegion.isEmpty()) return emptyList()
+        val spawnsInRegion = wg.getSpawnsForRegions(regions).takeUnless { it.isEmpty() } ?: return null
 
         // Check mob caps
-        val allowedSpawns = caps
-            .filterAllowedAt(location, spawnsInRegion.filter { it.position == position })
+        val allowedSpawns = caps.filterAllowedAt(location, spawnsInRegion.filterTo(ObjectArrayList()) { it.position == position })
 
         return allowedSpawns
     }
 
     fun chooseAllowedSpawnNear(location: Location, position: SpawnPosition): SpawnEntry? {
-        val allowedSpawns = getAllowedSpawnsNear(location, position)
-        if (allowedSpawns.isEmpty()) return null
-        return WeightedList(allowedSpawns.associateWith { it.priority }).roll()
+        val allowedSpawns = getAllowedSpawnsNear(location, position)?.takeUnless { it.isEmpty() } ?: return null
+        return WeightedList(allowedSpawns.associateWithTo(Object2ObjectOpenHashMap()) { it.priority }).roll()
     }
 }

--- a/geary-papermc-spawning/src/main/kotlin/com/mineinabyss/geary/papermc/spawning/choosing/mobcaps/MobCaps.kt
+++ b/geary-papermc-spawning/src/main/kotlin/com/mineinabyss/geary/papermc/spawning/choosing/mobcaps/MobCaps.kt
@@ -3,19 +3,39 @@ package com.mineinabyss.geary.papermc.spawning.choosing.mobcaps
 import com.mineinabyss.geary.papermc.spawning.components.SpawnCategory
 import com.mineinabyss.geary.papermc.spawning.config.SpawnEntry
 import com.mineinabyss.geary.papermc.spawning.spawn_types.GearyReadSpawnCategoryEvent
+import it.unimi.dsi.fastutil.objects.Object2IntArrayMap
+import it.unimi.dsi.fastutil.objects.ObjectArrayList
+import it.unimi.dsi.fastutil.objects.ObjectOpenHashSet
 import org.bukkit.Location
+import org.bukkit.entity.EntityType
+import org.bukkit.util.BoundingBox
 
 class MobCaps(
     val caps: Map<SpawnCategory, Int>,
     val defaultCapLimit: Int,
     val searchRadius: Int,
 ) {
-    fun calculateCategoriesNear(location: Location): Map<SpawnCategory, Int> = location
-        .getNearbyEntities(searchRadius.toDouble(), searchRadius.toDouble(), searchRadius.toDouble())
-        .groupingBy {
-            GearyReadSpawnCategoryEvent(it).also { it.callEvent() }.category ?: SpawnCategory.of(it)
-        }
-        .eachCount()
+    companion object {
+        private val IGNORED_ENTITY_TYPES = ObjectOpenHashSet.of<EntityType>(
+            EntityType.ITEM, EntityType.ITEM_FRAME, EntityType.GLOW_ITEM_FRAME, EntityType.BOAT, EntityType.CHEST_BOAT,
+            EntityType.MINECART, EntityType.HOPPER_MINECART, EntityType.COMMAND_BLOCK_MINECART, EntityType.CHEST_MINECART,
+            EntityType.FURNACE_MINECART, EntityType.SPAWNER_MINECART, EntityType.TNT_MINECART,
+            EntityType.EXPERIENCE_ORB, EntityType.FALLING_BLOCK, EntityType.ARROW, EntityType.SPECTRAL_ARROW,
+            EntityType.AREA_EFFECT_CLOUD, EntityType.INTERACTION, EntityType.BREEZE_WIND_CHARGE,
+            EntityType.DRAGON_FIREBALL, EntityType.EGG, EntityType.ENDER_PEARL, EntityType.EYE_OF_ENDER, EntityType.EVOKER_FANGS,
+            EntityType.EXPERIENCE_BOTTLE, EntityType.FIREBALL, EntityType.FIREWORK_ROCKET, EntityType.FISHING_BOBBER,
+            EntityType.LEASH_KNOT, EntityType.LIGHTNING_BOLT, EntityType.LLAMA_SPIT, EntityType.OMINOUS_ITEM_SPAWNER,
+            EntityType.TRIDENT, EntityType.POTION, EntityType.SHULKER_BULLET, EntityType.SMALL_FIREBALL, EntityType.SNOWBALL, EntityType.WIND_CHARGE
+        )
+    }
+
+    fun calculateCategoriesNear(location: Location): Map<SpawnCategory, Int> {
+        val boundingBox = BoundingBox.of(location, searchRadius.toDouble(), searchRadius.toDouble(), searchRadius.toDouble())
+        return location.world.getNearbyEntities(boundingBox) { it.type !in IGNORED_ENTITY_TYPES }
+            .groupingBy {
+                GearyReadSpawnCategoryEvent(it).also { it.callEvent() }.category ?: SpawnCategory.of(it)
+            }.eachCountTo(Object2IntArrayMap())
+    }
 
     fun filterAllowedAt(location: Location, spawns: List<SpawnEntry>): List<SpawnEntry> {
         val mobCaps = calculateCategoriesNear(location)

--- a/geary-papermc-spawning/src/main/kotlin/com/mineinabyss/geary/papermc/spawning/choosing/mobcaps/MobCaps.kt
+++ b/geary-papermc-spawning/src/main/kotlin/com/mineinabyss/geary/papermc/spawning/choosing/mobcaps/MobCaps.kt
@@ -9,6 +9,7 @@ import it.unimi.dsi.fastutil.objects.ObjectOpenHashSet
 import org.bukkit.Location
 import org.bukkit.entity.EntityType
 import org.bukkit.util.BoundingBox
+import java.util.function.Predicate
 
 class MobCaps(
     val caps: Map<SpawnCategory, Int>,
@@ -37,10 +38,15 @@ class MobCaps(
             }.eachCountTo(Object2IntArrayMap())
     }
 
-    fun filterAllowedAt(location: Location, spawns: List<SpawnEntry>): List<SpawnEntry> {
+    fun filterAllowedAt(location: Location, spawns: List<SpawnEntry>, predicate: Predicate<SpawnEntry>): ObjectArrayList<SpawnEntry> {
         val mobCaps = calculateCategoriesNear(location)
-        return spawns.filterTo(ObjectArrayList()) {
-            mobCaps.getOrDefault(it.type.category, 0) < caps.getOrDefault(it.type.category, defaultCapLimit)
+        val defaultLimit = this.defaultCapLimit
+
+        return spawns.filterTo(ObjectArrayList(spawns.size)) { spawn ->
+            val category = spawn.type.category
+            val currentCount = mobCaps.getOrDefault(category, 0)
+            val limit = caps.getOrDefault(category, defaultLimit)
+            currentCount < limit && predicate.test(spawn)
         }
     }
 

--- a/geary-papermc-spawning/src/main/kotlin/com/mineinabyss/geary/papermc/spawning/choosing/mobcaps/MobCaps.kt
+++ b/geary-papermc-spawning/src/main/kotlin/com/mineinabyss/geary/papermc/spawning/choosing/mobcaps/MobCaps.kt
@@ -19,11 +19,8 @@ class MobCaps(
 
     fun filterAllowedAt(location: Location, spawns: List<SpawnEntry>): List<SpawnEntry> {
         val mobCaps = calculateCategoriesNear(location)
-        return spawns.filter {
-            mobCaps.getOrDefault(it.type.category, 0) < caps.getOrDefault(
-                it.type.category,
-                defaultCapLimit,
-            )
+        return spawns.filterTo(ObjectArrayList()) {
+            mobCaps.getOrDefault(it.type.category, 0) < caps.getOrDefault(it.type.category, defaultCapLimit)
         }
     }
 

--- a/geary-papermc-spawning/src/main/kotlin/com/mineinabyss/geary/papermc/spawning/choosing/mobcaps/MobCaps.kt
+++ b/geary-papermc-spawning/src/main/kotlin/com/mineinabyss/geary/papermc/spawning/choosing/mobcaps/MobCaps.kt
@@ -3,8 +3,6 @@ package com.mineinabyss.geary.papermc.spawning.choosing.mobcaps
 import com.mineinabyss.geary.papermc.spawning.components.SpawnCategory
 import com.mineinabyss.geary.papermc.spawning.config.SpawnEntry
 import com.mineinabyss.geary.papermc.spawning.spawn_types.GearyReadSpawnCategoryEvent
-import it.unimi.dsi.fastutil.objects.Object2IntArrayMap
-import it.unimi.dsi.fastutil.objects.ObjectArrayList
 import it.unimi.dsi.fastutil.objects.ObjectOpenHashSet
 import org.bukkit.Location
 import org.bukkit.entity.EntityType
@@ -35,14 +33,14 @@ class MobCaps(
         return location.world.getNearbyEntities(boundingBox) { it.type !in IGNORED_ENTITY_TYPES }
             .groupingBy {
                 GearyReadSpawnCategoryEvent(it).also { it.callEvent() }.category ?: SpawnCategory.of(it)
-            }.eachCountTo(Object2IntArrayMap())
+            }.eachCount()
     }
 
-    fun filterAllowedAt(location: Location, spawns: List<SpawnEntry>, predicate: Predicate<SpawnEntry>): ObjectArrayList<SpawnEntry> {
+    fun filterAllowedAt(location: Location, spawns: List<SpawnEntry>, predicate: Predicate<SpawnEntry>): List<SpawnEntry> {
         val mobCaps = calculateCategoriesNear(location)
         val defaultLimit = this.defaultCapLimit
 
-        return spawns.filterTo(ObjectArrayList(spawns.size)) { spawn ->
+        return spawns.filter { spawn ->
             val category = spawn.type.category
             val currentCount = mobCaps.getOrDefault(category, 0)
             val limit = caps.getOrDefault(category, defaultLimit)

--- a/geary-papermc-spawning/src/main/kotlin/com/mineinabyss/geary/papermc/spawning/choosing/worldguard/WorldGuardSpawning.kt
+++ b/geary-papermc-spawning/src/main/kotlin/com/mineinabyss/geary/papermc/spawning/choosing/worldguard/WorldGuardSpawning.kt
@@ -3,8 +3,8 @@ package com.mineinabyss.geary.papermc.spawning.choosing.worldguard
 import com.mineinabyss.geary.papermc.spawning.config.SpawnEntry
 import com.sk89q.worldedit.bukkit.BukkitAdapter
 import com.sk89q.worldguard.WorldGuard
-import com.sk89q.worldguard.protection.flags.StateFlag
 import com.sk89q.worldguard.protection.regions.ProtectedRegion
+import it.unimi.dsi.fastutil.objects.ObjectArrayList
 import org.bukkit.Location
 
 class WorldGuardSpawning(
@@ -31,5 +31,5 @@ class WorldGuardSpawning(
 
     fun getSpawnsForRegions(
         regions: List<ProtectedRegion>,
-    ): List<SpawnEntry> = regions.flatMap { regionToSpawns[it.id] ?: emptyList() }
+    ): List<SpawnEntry> = regions.flatMapTo(ObjectArrayList()) { regionToSpawns[it.id] ?: emptyList() }
 }

--- a/geary-papermc-spawning/src/main/kotlin/com/mineinabyss/geary/papermc/spawning/choosing/worldguard/WorldGuardSpawning.kt
+++ b/geary-papermc-spawning/src/main/kotlin/com/mineinabyss/geary/papermc/spawning/choosing/worldguard/WorldGuardSpawning.kt
@@ -16,7 +16,7 @@ class WorldGuardSpawning(
 
     private val regionContainer = WorldGuard.getInstance().platform.regionContainer
 
-    fun getRegionsAt(location: Location): List<ProtectedRegion> {
+    fun getRegionsAt(location: Location): ObjectArrayList<ProtectedRegion> {
         val allRegions = regionContainer
             .createQuery()
             .getApplicableRegions(BukkitAdapter.adapt(location))
@@ -26,10 +26,10 @@ class WorldGuardSpawning(
         val dropAt = allRegions
             .indexOfLast { it.getFlag(SpawningWorldGuardFlags.OVERRIDE_LOWER_PRIORITY_SPAWNS) == true }
             .coerceAtLeast(0)
-        return allRegions.drop(dropAt)
+        return ObjectArrayList(allRegions.drop(dropAt))
     }
 
     fun getSpawnsForRegions(
-        regions: List<ProtectedRegion>,
-    ): List<SpawnEntry> = regions.flatMapTo(ObjectArrayList()) { regionToSpawns[it.id] ?: emptyList() }
+        regions: ObjectArrayList<ProtectedRegion>,
+    ): ObjectArrayList<SpawnEntry> = regions.flatMapTo(ObjectArrayList()) { regionToSpawns[it.id] ?: emptyList() }
 }

--- a/geary-papermc-spawning/src/main/kotlin/com/mineinabyss/geary/papermc/spawning/choosing/worldguard/WorldGuardSpawning.kt
+++ b/geary-papermc-spawning/src/main/kotlin/com/mineinabyss/geary/papermc/spawning/choosing/worldguard/WorldGuardSpawning.kt
@@ -4,7 +4,6 @@ import com.mineinabyss.geary.papermc.spawning.config.SpawnEntry
 import com.sk89q.worldedit.bukkit.BukkitAdapter
 import com.sk89q.worldguard.WorldGuard
 import com.sk89q.worldguard.protection.regions.ProtectedRegion
-import it.unimi.dsi.fastutil.objects.ObjectArrayList
 import org.bukkit.Location
 
 class WorldGuardSpawning(
@@ -16,7 +15,7 @@ class WorldGuardSpawning(
 
     private val regionContainer = WorldGuard.getInstance().platform.regionContainer
 
-    fun getRegionsAt(location: Location): ObjectArrayList<ProtectedRegion> {
+    fun getRegionsAt(location: Location): List<ProtectedRegion> {
         val allRegions = regionContainer
             .createQuery()
             .getApplicableRegions(BukkitAdapter.adapt(location))
@@ -26,10 +25,10 @@ class WorldGuardSpawning(
         val dropAt = allRegions
             .indexOfLast { it.getFlag(SpawningWorldGuardFlags.OVERRIDE_LOWER_PRIORITY_SPAWNS) == true }
             .coerceAtLeast(0)
-        return ObjectArrayList(allRegions.drop(dropAt))
+        return allRegions.drop(dropAt)
     }
 
     fun getSpawnsForRegions(
-        regions: ObjectArrayList<ProtectedRegion>,
-    ): ObjectArrayList<SpawnEntry> = regions.flatMapTo(ObjectArrayList()) { regionToSpawns[it.id] ?: emptyList() }
+        regions: List<ProtectedRegion>,
+    ): List<SpawnEntry> = regions.flatMap { regionToSpawns[it.id] ?: emptyList() }
 }

--- a/geary-papermc-spawning/src/main/kotlin/com/mineinabyss/geary/papermc/spawning/helpers/WeightedList.kt
+++ b/geary-papermc-spawning/src/main/kotlin/com/mineinabyss/geary/papermc/spawning/helpers/WeightedList.kt
@@ -1,7 +1,6 @@
 package com.mineinabyss.geary.papermc.spawning.helpers
 
 import com.mineinabyss.idofront.util.DoubleRange
-import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap
 import java.util.concurrent.ThreadLocalRandom
 
 /**
@@ -17,7 +16,7 @@ class WeightedList<T>(val probabilities: Map<T, Double>) {
         prob.asSequence().sortedBy { it.value }
             .map { it.key to binStart..(it.value + binStart) }
             .onEach { binStart = it.second.endInclusive }
-            .toMap(Object2ObjectOpenHashMap())
+            .toMap()
     }
 
     /**

--- a/geary-papermc-spawning/src/main/kotlin/com/mineinabyss/geary/papermc/spawning/helpers/WeightedList.kt
+++ b/geary-papermc-spawning/src/main/kotlin/com/mineinabyss/geary/papermc/spawning/helpers/WeightedList.kt
@@ -1,6 +1,7 @@
 package com.mineinabyss.geary.papermc.spawning.helpers
 
 import com.mineinabyss.idofront.util.DoubleRange
+import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap
 import java.util.concurrent.ThreadLocalRandom
 
 /**
@@ -16,7 +17,7 @@ class WeightedList<T>(val probabilities: Map<T, Double>) {
         prob.asSequence().sortedBy { it.value }
             .map { it.key to binStart..(it.value + binStart) }
             .onEach { binStart = it.second.endInclusive }
-            .toMap()
+            .toMap(Object2ObjectOpenHashMap())
     }
 
     /**

--- a/geary-papermc-spawning/src/main/kotlin/com/mineinabyss/geary/papermc/spawning/tasks/SpawnTask.kt
+++ b/geary-papermc-spawning/src/main/kotlin/com/mineinabyss/geary/papermc/spawning/tasks/SpawnTask.kt
@@ -38,7 +38,6 @@ class SpawnTask(
         val allowedSpawnPositions: List<SpawnPosition> = SpawnPosition.entries
             .filterTo(ObjectArrayList()) { currTick % runTimes.getOrDefault(it, 1.ticks).inWholeTicks == 0L }
             .takeUnless { it.isEmpty() } ?: return
-        if (allowedSpawnPositions.isEmpty()) return
         val onlinePlayers = Bukkit.getOnlinePlayers().filterTo(ObjectArrayList()) { !it.isDead && it.gameMode != SPECTATOR }
 
         onlinePlayers.forEach { player ->

--- a/geary-papermc-spawning/src/main/kotlin/com/mineinabyss/geary/papermc/spawning/tasks/SpawnTask.kt
+++ b/geary-papermc-spawning/src/main/kotlin/com/mineinabyss/geary/papermc/spawning/tasks/SpawnTask.kt
@@ -8,7 +8,6 @@ import com.mineinabyss.geary.papermc.spawning.config.SpawnPosition
 import com.mineinabyss.geary.papermc.spawning.readers.SpawnPositionReader
 import com.mineinabyss.idofront.time.inWholeTicks
 import com.mineinabyss.idofront.time.ticks
-import it.unimi.dsi.fastutil.objects.ObjectArrayList
 import it.unimi.dsi.fastutil.objects.ObjectOpenHashSet
 import kotlinx.coroutines.delay
 import org.bukkit.Bukkit
@@ -36,12 +35,12 @@ class SpawnTask(
     fun run() {
         val currTick = Bukkit.getCurrentTick()
         val allowedSpawnPositions: List<SpawnPosition> = SpawnPosition.entries
-            .filterTo(ObjectArrayList()) { currTick % runTimes.getOrDefault(it, 1.ticks).inWholeTicks == 0L }
+            .filter { currTick % runTimes.getOrDefault(it, 1.ticks).inWholeTicks == 0L }
             .takeUnless { it.isEmpty() } ?: return
-        val onlinePlayers = Bukkit.getOnlinePlayers().filterTo(ObjectArrayList()) { !it.isDead && it.gameMode != SPECTATOR }
+        val onlinePlayers = Bukkit.getOnlinePlayers().filter { !it.isDead && it.gameMode != SPECTATOR }
 
         onlinePlayers.forEach { player ->
-            val attemptedPositions = ObjectOpenHashSet(allowedSpawnPositions)
+            val attemptedPositions = allowedSpawnPositions.toMutableSet()
             repeat(spawnAttempts) {
                 if (attemptedPositions.isEmpty()) return@forEach
                 val spawnLoc = locationChooser.chooseSpawnLocationNear(onlinePlayers, player.location) ?: return@repeat


### PR DESCRIPTION
Swaps spawning to use FastUtil lists and maps where possible
Also swaps the main taxing entity lookup to filter out guaranteed not used entity types
Excluding all the "temporary" projectiles and exp orbs etc, this is atleast a 45% reduction in entities it checks on average

![image](https://github.com/user-attachments/assets/6a76f824-af15-45c9-80a9-eddf90a75f2b)
