### PR TITLE
feat: duck cooldown display

### DIFF
--- a/geary-papermc-features/src/main/kotlin/com/mineinabyss/geary/papermc/features/common/cooldowns/CooldownCondition.kt
+++ b/geary-papermc-features/src/main/kotlin/com/mineinabyss/geary/papermc/features/common/cooldowns/CooldownCondition.kt
@@ -19,7 +19,10 @@ data class StartedCooldown(
     val display: @Serializable(with = MiniMessageSerializer::class) net.kyori.adventure.text.Component? = null,
 ) {
     val timeLeft: Duration get() = (endTime - System.currentTimeMillis()).milliseconds
-
+    val startDuration: Int = 1000 // Hardcoded
+    val endDuration: Int = 1000   // Hardcoded
+    val startTime: Long = endTime - length.inWholeMilliseconds
+    fun isVisible(): Boolean = System.currentTimeMillis() <= startTime + startDuration || System.currentTimeMillis() >= endTime - endDuration
     fun isComplete(): Boolean = System.currentTimeMillis() >= endTime
 }
 

--- a/geary-papermc-features/src/main/kotlin/com/mineinabyss/geary/papermc/features/common/cooldowns/CooldownDisplaySystem.kt
+++ b/geary-papermc-features/src/main/kotlin/com/mineinabyss/geary/papermc/features/common/cooldowns/CooldownDisplaySystem.kt
@@ -20,7 +20,7 @@ fun Geary.cooldownDisplaySystem() = system(query<Player, Cooldowns>())
         if (!cooldowns.hasDisplayableCooldowns) return@exec
 
         val cooldownsWithDisplay = cooldowns.cooldowns.values.filter {
-            it.display != null
+            it.display != null && it.isVisible()
         }
 
         if (cooldownsWithDisplay.isEmpty()) return@exec


### PR DESCRIPTION
Hides the cooldown bar after a certain duration and displays it again once the cooldown is a certain duration from expiring.