### PR TITLE
refactor: swap loads of item-logic off ItemMeta#getPersistentDataContainer

### DIFF
--- a/geary-papermc-datastore/src/main/kotlin/com/mineinabyss/geary/papermc/datastore/ContainerHelpers.kt
+++ b/geary-papermc-datastore/src/main/kotlin/com/mineinabyss/geary/papermc/datastore/ContainerHelpers.kt
@@ -8,6 +8,7 @@ import com.mineinabyss.geary.serialization.components.Persists
 import com.mineinabyss.geary.serialization.getAllPersisting
 import com.mineinabyss.geary.serialization.setAllPersisting
 import com.mineinabyss.idofront.typealiases.BukkitEntity
+import io.papermc.paper.persistence.PersistentDataContainerView
 import org.bukkit.inventory.ItemStack
 import org.bukkit.persistence.PersistentDataContainer
 import org.bukkit.persistence.PersistentDataHolder
@@ -35,12 +36,12 @@ fun GearyEntity.encodeComponentsTo(holder: PersistentDataHolder) {
 
 context(Geary)
 fun GearyEntity.encodeComponentsTo(item: ItemStack) {
-    item.editMeta { encodeComponentsTo(it.persistentDataContainer) }
+    item.editPersistentDataContainer(::encodeComponentsTo)
 }
 
 
 /** Decodes a [PersistentDataContainer]'s components, adding them to this entity and its list of persisting components */
-fun GearyEntity.loadComponentsFrom(pdc: PersistentDataContainer) {
+fun GearyEntity.loadComponentsFrom(pdc: PersistentDataContainerView) {
     loadComponentsFrom(with(world) { pdc.decodeComponents() })
 }
 
@@ -61,4 +62,4 @@ fun PersistentDataHolder.decodeComponents(): DecodedEntityData =
 
 context(Geary)
 fun ItemStack.decodeComponents(): DecodedEntityData =
-    itemMeta.decodeComponents()
+    persistentDataContainer.decodeComponents()

--- a/geary-papermc-features/src/main/kotlin/com/mineinabyss/geary/papermc/features/items/recipes/RecipeCraftingListener.kt
+++ b/geary-papermc-features/src/main/kotlin/com/mineinabyss/geary/papermc/features/items/recipes/RecipeCraftingListener.kt
@@ -28,11 +28,7 @@ class RecipeCraftingListener : Listener {
         if (recipe == null || (recipe as? Keyed)?.key()?.namespace() != "minecraft") return
 
         if (inventory.matrix.any {
-                entityOfOrNull(
-                    it?.itemMeta?.persistentDataContainer
-                        ?.decodePrefabs()
-                        ?.firstOrNull()
-                )
+                entityOfOrNull(it?.persistentDataContainer?.decodePrefabs()?.firstOrNull())
                     ?.has<DenyInVanillaRecipes>() == true
             }) {
             inventory.result = null
@@ -50,12 +46,12 @@ class RecipeCraftingListener : Listener {
         val (template, mineral) = (inventory.inputTemplate ?: return) to (inventory.inputMineral ?: return)
         val equipment = inventory.inputEquipment ?: return
 
-        val inputGearyEntity = equipment.fastPDC?.decodePrefabs()?.firstOrNull() ?: return
+        val inputGearyEntity = equipment.persistentDataContainer.decodePrefabs().firstOrNull() ?: return
         val smithingTransformRecipes = Bukkit.recipeIterator().asSequence()
             .filterIsInstance<SmithingTransformRecipe>()
             .filter { it.result.fastPDC?.hasComponentsEncoded == true }
         val customRecipeResult = smithingTransformRecipes.filter {
-            it.base.itemStack.itemMeta?.persistentDataContainer?.decodePrefabs()?.firstOrNull() == inputGearyEntity
+            it.base.itemStack.persistentDataContainer.decodePrefabs().firstOrNull() == inputGearyEntity
                     && it.template.test(template) && it.addition.test(mineral)
         }.firstOrNull()?.result
 

--- a/geary-papermc-features/src/main/kotlin/com/mineinabyss/geary/papermc/features/items/resourcepacks/ResourcePackContent.kt
+++ b/geary-papermc-features/src/main/kotlin/com/mineinabyss/geary/papermc/features/items/resourcepacks/ResourcePackContent.kt
@@ -1,15 +1,12 @@
 package com.mineinabyss.geary.papermc.features.items.resourcepacks
 
 import com.mineinabyss.idofront.serialization.*
-import io.papermc.paper.datacomponent.DataComponentTypes
 import kotlinx.serialization.EncodeDefault
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import net.kyori.adventure.key.Key
 import org.bukkit.Material
-import org.bukkit.inventory.ItemStack
 import team.unnamed.creative.item.tint.TintSource
-import team.unnamed.creative.model.ItemPredicate
 
 @Serializable
 @SerialName("geary:resourcepack")
@@ -55,10 +52,5 @@ data class ResourcePackContent(
         @EncodeDefault(EncodeDefault.Mode.NEVER) val pullingTextures: Map<@Serializable(KeySerializer::class) Key, Float> = emptyMap(),
         @EncodeDefault(EncodeDefault.Mode.NEVER) val timeModels: Map<@Serializable(KeySerializer::class) Key, Float> = emptyMap(),
         @EncodeDefault(EncodeDefault.Mode.NEVER) val timeTextures: Map<@Serializable(KeySerializer::class) Key, Float> = emptyMap(),
-    ) {
-        fun customModelData(itemStack: ItemStack?): ItemPredicate? =
-            (customModelData ?: itemStack?.getData(DataComponentTypes.CUSTOM_MODEL_DATA)?.floats()?.firstOrNull()?.toInt())?.let(
-                ItemPredicate::customModelData
-            )
-    }
+    )
 }

--- a/geary-papermc-features/src/main/kotlin/com/mineinabyss/geary/papermc/features/items/resourcepacks/ResourcePackContent.kt
+++ b/geary-papermc-features/src/main/kotlin/com/mineinabyss/geary/papermc/features/items/resourcepacks/ResourcePackContent.kt
@@ -1,12 +1,7 @@
 package com.mineinabyss.geary.papermc.features.items.resourcepacks
 
-import com.mineinabyss.geary.modules.Geary
-import com.mineinabyss.geary.prefabs.PrefabKey
-import com.mineinabyss.idofront.serialization.KeySerializer
-import com.mineinabyss.idofront.serialization.MaterialByNameSerializer
-import com.mineinabyss.idofront.serialization.ModelTexturesSerializer
-import com.mineinabyss.idofront.serialization.ModelTexturesSurrogate
-import com.mineinabyss.idofront.serialization.TintSourceSerializer
+import com.mineinabyss.idofront.serialization.*
+import io.papermc.paper.datacomponent.DataComponentTypes
 import kotlinx.serialization.EncodeDefault
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
@@ -14,7 +9,6 @@ import net.kyori.adventure.key.Key
 import org.bukkit.Material
 import org.bukkit.inventory.ItemStack
 import team.unnamed.creative.item.tint.TintSource
-import team.unnamed.creative.model.ItemOverride
 import team.unnamed.creative.model.ItemPredicate
 
 @Serializable
@@ -32,94 +26,6 @@ data class ResourcePackContent(
     init {
         require(itemModel != null || model != null || textures.layers.isNotEmpty() || textures.variables.isNotEmpty()) { "ResourcePackContent must contain atleast an itemModel, model or texture reference" }
     }
-
-    fun itemOverrides(modelKey: Key, prefabKey: PrefabKey, itemStack: ItemStack?): List<ItemOverride> {
-        val overrides = mutableListOf<ItemOverride>()
-        val cmdPredicate = itemPredicates.customModelData(itemStack) ?: run {
-            Geary.w("$prefabKey has no CustomModelData specified in either ResourcePackContent or SerializableItemStack components")
-            ItemPredicate.customModelData(0)
-        }
-
-        // Shields
-        (itemPredicates.blockingModel ?: itemPredicates.blockingTexture?.let { modelKey.plus("_blocking") })?.let {
-            overrides.add(ItemOverride.of(it, cmdPredicate, ItemPredicate.blocking()))
-        }
-        // Elytras
-        (itemPredicates.brokenModel ?: itemPredicates.brokenTexture?.let { modelKey.plus("_broken") })?.let {
-            overrides.add(ItemOverride.of(it, cmdPredicate, ItemPredicate.broken()))
-        }
-        // Fishing Rods
-        overrides.add(ItemOverride.of(modelKey, cmdPredicate))
-        (itemPredicates.castModel ?: itemPredicates.castTexture?.let { modelKey.plus("_cast") })?.let {
-            overrides.add(ItemOverride.of(it, cmdPredicate, ItemPredicate.cast()))
-        }
-        // Charged Crossbow
-        (itemPredicates.chargedModel ?: itemPredicates.chargedTexture?.let { modelKey.plus("_charged") })?.let {
-            overrides.add(ItemOverride.of(it, cmdPredicate, ItemPredicate.charged()))
-        }
-        // Charged Crossbow with Firework
-        (itemPredicates.fireworkModel ?: itemPredicates.fireworkTexture?.let { modelKey.plus("_firework") })?.let {
-            overrides.add(ItemOverride.of(it, cmdPredicate, ItemPredicate.firework()))
-        }
-        // Lefthanded-players
-        (itemPredicates.lefthandedModel
-            ?: itemPredicates.lefthandedTexture?.let { modelKey.plus("_lefthanded") })?.let {
-            overrides.add(ItemOverride.of(it, cmdPredicate, ItemPredicate.lefthanded()))
-        }
-        // Tridents
-        (itemPredicates.throwingModel ?: itemPredicates.throwingTexture?.let { modelKey.plus("_throwing") })?.let {
-            overrides.add(ItemOverride.of(it, cmdPredicate, ItemPredicate.throwing()))
-        }
-
-        fun Map<Key, Float>.predicateModel(suffix: String, action: (Map.Entry<Key, Float>) -> ItemOverride) =
-            this.toList()
-                .mapIndexed { index, (_, damage) -> modelKey.plus("_${suffix}_$index") to damage.coerceIn(0f..1f) }
-                .toMap().map(action).forEach(overrides::add)
-        // Compasses
-        itemPredicates.angleModels.takeUnless { it.isEmpty() }
-            ?: itemPredicates.angleTextures.predicateModel("angle") { (key, angle) ->
-                ItemOverride.of(key, cmdPredicate, ItemPredicate.angle(angle))
-            }
-        // Cooldown remaining on an item
-        itemPredicates.cooldownModels.takeUnless { it.isEmpty() }
-            ?: itemPredicates.cooldownTextures.predicateModel("cooldown") { (key, damage) ->
-                ItemOverride.of(
-                    key,
-                    cmdPredicate,
-                    ItemPredicate.damaged(),
-                    ItemPredicate.cooldown(damage)
-                )
-            }
-        // Durability of an item
-        itemPredicates.damageModels.takeUnless { it.isEmpty() }
-            ?: itemPredicates.damageTextures.predicateModel("damage") { (key, damage) ->
-                ItemOverride.of(
-                    key,
-                    cmdPredicate,
-                    ItemPredicate.damaged(),
-                    ItemPredicate.damage(damage)
-                )
-            }
-        // Bows & Crossbows
-        itemPredicates.pullingModels.takeUnless { it.isEmpty() }
-            ?: itemPredicates.pullingTextures.predicateModel("pulling") { (key, pulling) ->
-                ItemOverride.of(
-                    key,
-                    cmdPredicate,
-                    ItemPredicate.pulling(),
-                    ItemPredicate.pull(pulling)
-                )
-            }
-        // Clocks
-        itemPredicates.timeModels.takeUnless { it.isEmpty() }
-            ?: itemPredicates.timeTextures.predicateModel("time") { (key, time) ->
-                ItemOverride.of(key, cmdPredicate, ItemPredicate.time(time))
-            }
-
-        return overrides
-    }
-
-    private fun Key.plus(suffix: String) = Key.key(namespace(), value().plus(suffix))
 
     @Serializable
     data class ItemPredicates(
@@ -151,7 +57,7 @@ data class ResourcePackContent(
         @EncodeDefault(EncodeDefault.Mode.NEVER) val timeTextures: Map<@Serializable(KeySerializer::class) Key, Float> = emptyMap(),
     ) {
         fun customModelData(itemStack: ItemStack?): ItemPredicate? =
-            (customModelData ?: itemStack?.itemMeta?.takeIf { it.hasCustomModelData() }?.customModelData)?.let(
+            (customModelData ?: itemStack?.getData(DataComponentTypes.CUSTOM_MODEL_DATA)?.floats()?.firstOrNull()?.toInt())?.let(
                 ItemPredicate::customModelData
             )
     }

--- a/geary-papermc-spawning/src/main/kotlin/com/mineinabyss/geary/papermc/spawning/choosing/mobcaps/MobCaps.kt
+++ b/geary-papermc-spawning/src/main/kotlin/com/mineinabyss/geary/papermc/spawning/choosing/mobcaps/MobCaps.kt
@@ -3,6 +3,7 @@ package com.mineinabyss.geary.papermc.spawning.choosing.mobcaps
 import com.mineinabyss.geary.papermc.spawning.components.SpawnCategory
 import com.mineinabyss.geary.papermc.spawning.config.SpawnEntry
 import com.mineinabyss.geary.papermc.spawning.spawn_types.GearyReadSpawnCategoryEvent
+import com.mineinabyss.idofront.events.call
 import it.unimi.dsi.fastutil.objects.ObjectOpenHashSet
 import org.bukkit.Location
 import org.bukkit.entity.EntityType
@@ -35,10 +36,10 @@ class MobCaps(
 
     fun calculateCategoriesNear(location: Location): Map<SpawnCategory, Int> {
         val boundingBox = BoundingBox.of(location, searchRadius.toDouble(), searchRadius.toDouble(), searchRadius.toDouble())
-        return location.world.getNearbyEntities(boundingBox) { it.type !in IGNORED_ENTITY_TYPES }
-            .groupingBy {
-                GearyReadSpawnCategoryEvent(it).also { it.callEvent() }.category ?: SpawnCategory.of(it)
-            }.eachCount()
+        val entities = location.world.getNearbyEntities(boundingBox) { it.type !in IGNORED_ENTITY_TYPES }
+        return entities.groupingBy {
+            GearyReadSpawnCategoryEvent(it).also { it.call() }.category ?: SpawnCategory.of(it)
+        }.eachCount()
     }
 
     fun filterAllowedAt(location: Location, spawns: List<SpawnEntry>, predicate: Predicate<SpawnEntry>): List<SpawnEntry> {

--- a/geary-papermc-spawning/src/main/kotlin/com/mineinabyss/geary/papermc/spawning/spawn_types/geary/GearySpawnTypeListener.kt
+++ b/geary-papermc-spawning/src/main/kotlin/com/mineinabyss/geary/papermc/spawning/spawn_types/geary/GearySpawnTypeListener.kt
@@ -9,9 +9,7 @@ import org.bukkit.event.Listener
 class GearySpawnTypeListener : Listener {
     @EventHandler
     fun GearyReadSpawnCategoryEvent.readSpawnCategory() {
-        if (category != null) return
-        val cat = entity.toGearyOrNull()?.get<SpawnCategory>() ?: return
-        category = cat
+        if (category == null) category = entity.toGearyOrNull()?.get<SpawnCategory>()
     }
 }
 

--- a/geary-papermc-tracking/src/main/kotlin/com/mineinabyss/geary/papermc/tracking/items/GearyItemContext.kt
+++ b/geary-papermc-tracking/src/main/kotlin/com/mineinabyss/geary/papermc/tracking/items/GearyItemContext.kt
@@ -3,7 +3,6 @@ package com.mineinabyss.geary.papermc.tracking.items
 import com.mineinabyss.geary.datatypes.GearyEntity
 import com.mineinabyss.geary.helpers.entity
 import com.mineinabyss.geary.modules.Geary
-import com.mineinabyss.idofront.nms.nbt.fastPDC
 import org.bukkit.inventory.ItemStack
 import java.io.Closeable
 
@@ -20,14 +19,18 @@ class GearyItemContext(
 
     fun ItemStack.toGearyOrNull(): GearyEntity? {
         return cached.getOrPut(this) {
-            gearyItems.itemProvider.deserializeItemStackToEntity(this.fastPDC)?.apply {
-                set<ItemStack>(this@toGearyOrNull)
-            } ?: return null
+            var entity: GearyEntity? = null
+            editPersistentDataContainer {
+                entity = gearyItems.itemProvider.deserializeItemStackToEntity(it)?.apply {
+                    set<ItemStack>(this@toGearyOrNull)
+                }
+            }
+            return entity
         }
     }
 
     override fun close() {
-        cached.forEach { (item, entity) -> entity.removeEntity() }
+        cached.forEach { (_, entity) -> entity.removeEntity() }
     }
 }
 

--- a/geary-papermc-tracking/src/main/kotlin/com/mineinabyss/geary/papermc/tracking/items/GearyItemProvider.kt
+++ b/geary-papermc-tracking/src/main/kotlin/com/mineinabyss/geary/papermc/tracking/items/GearyItemProvider.kt
@@ -11,7 +11,6 @@ import com.mineinabyss.geary.papermc.datastore.loadComponentsFrom
 import com.mineinabyss.geary.papermc.tracking.items.components.SetItem
 import com.mineinabyss.geary.prefabs.PrefabKey
 import com.mineinabyss.geary.prefabs.entityOfOrNull
-import com.mineinabyss.idofront.items.editItemMeta
 import org.bukkit.Material
 import org.bukkit.inventory.ItemStack
 import org.bukkit.persistence.PersistentDataContainer
@@ -24,8 +23,8 @@ class GearyItemProvider(world: Geary) : Geary by world {
     fun serializePrefabToItemStack(prefabKey: PrefabKey, existing: ItemStack? = null): ItemStack? {
         val prefab = entityOfOrNull(prefabKey) ?: return null
 
-        return prefab.get<SetItem>()?.item?.toItemStackOrNull(existing ?: ItemStack(Material.AIR))?.editItemMeta {
-            persistentDataContainer.encodePrefabs(listOf(prefabKey))
+        return prefab.get<SetItem>()?.item?.toItemStackOrNull(existing ?: ItemStack(Material.AIR))?.apply {
+            editPersistentDataContainer { it.encodePrefabs(listOf(prefabKey)) }
         }
     }
 

--- a/geary-papermc-tracking/src/main/kotlin/com/mineinabyss/geary/papermc/tracking/items/ItemTracking.kt
+++ b/geary-papermc-tracking/src/main/kotlin/com/mineinabyss/geary/papermc/tracking/items/ItemTracking.kt
@@ -31,8 +31,6 @@ val ItemTracking = createAddon<ItemTrackingModule>("Item Tracking", { NMSBackedI
         createInventoryTrackerSystem()
     }
     onPluginEnable {
-        plugin.listeners(
-            configuration.loginListener,
-        )
+        plugin.listeners(configuration.loginListener)
     }
 }

--- a/geary-papermc-tracking/src/main/kotlin/com/mineinabyss/geary/papermc/tracking/items/cache/BukkitItemCache.kt
+++ b/geary-papermc-tracking/src/main/kotlin/com/mineinabyss/geary/papermc/tracking/items/cache/BukkitItemCache.kt
@@ -19,7 +19,11 @@ class BukkitItemCache(
     }
 
     override fun deserializeItem(item: ItemStack): GearyEntity? {
-        return gearyItems.itemProvider.deserializeItemStackToEntity(item.itemMeta.persistentDataContainer)
+        var entity: GearyEntity? = null
+        item.editPersistentDataContainer {
+            entity = gearyItems.itemProvider.deserializeItemStackToEntity(it)
+        }
+        return entity
     }
 
     override fun skipUpdate(slot: Int, newItem: ItemStack?): Boolean {

--- a/geary-papermc-tracking/src/main/kotlin/com/mineinabyss/geary/papermc/tracking/items/cache/PlayerItemCache.kt
+++ b/geary-papermc-tracking/src/main/kotlin/com/mineinabyss/geary/papermc/tracking/items/cache/PlayerItemCache.kt
@@ -27,8 +27,7 @@ abstract class PlayerItemCache<T>(
     private fun removeEntity(slot: Int) {
         val entity = entities[slot].takeIf { it != 0uL }?.toGeary() ?: return
         logger.v { "Removing ${entities[slot]} in slot $slot" }
-        val pdc = entity.get<ItemStack>()?.itemMeta?.persistentDataContainer
-        if (pdc != null) entity.encodeComponentsTo(pdc)
+        entity.get<ItemStack>()?.editPersistentDataContainer(entity::encodeComponentsTo)
         entity.removeEntity()
         entities[slot] = 0uL
     }

--- a/geary-papermc-tracking/src/main/kotlin/com/mineinabyss/geary/papermc/tracking/items/migration/SetItemMigrationSystem.kt
+++ b/geary-papermc-tracking/src/main/kotlin/com/mineinabyss/geary/papermc/tracking/items/migration/SetItemMigrationSystem.kt
@@ -5,7 +5,7 @@ import com.mineinabyss.geary.modules.observe
 import com.mineinabyss.geary.observers.events.OnSet
 import com.mineinabyss.geary.papermc.tracking.items.components.SetItem
 import com.mineinabyss.geary.systems.query.query
-import com.mineinabyss.idofront.items.editItemMeta
+import io.papermc.paper.datacomponent.DataComponentTypes
 import net.kyori.adventure.text.serializer.plain.PlainTextComponentSerializer
 import org.bukkit.inventory.ItemStack
 
@@ -17,14 +17,10 @@ fun Geary.createItemMigrationListener() = observe<OnSet>()
         setItem.item.toItemStack(applyTo = item)
 
         // Migrate display name -> item name
-        val newItem = setItem.item
-        val oldCustomName = item.itemMeta.displayName()
-        val newItemName = newItem.itemName
+        val itemName = setItem.item.takeIf { it.itemName != null && it.customName == null }?.itemName ?: return@exec
+        val customName = item.getData(DataComponentTypes.CUSTOM_NAME) ?: return@exec
 
         // if old item name matches new one, ignoring formatting, remove it
-        if (newItem.customName == null && newItemName != null && oldCustomName != null &&
-            plainTextSerializer.serialize(oldCustomName) == plainTextSerializer.serialize(newItemName)
-        ) item.editItemMeta {
-            displayName(null)
-        }
+        if (plainTextSerializer.serialize(customName) == plainTextSerializer.serialize(itemName))
+            item.unsetData(DataComponentTypes.CUSTOM_NAME)
     }

--- a/geary-papermc-tracking/src/main/kotlin/com/mineinabyss/geary/papermc/tracking/items/systems/LoginListener.kt
+++ b/geary-papermc-tracking/src/main/kotlin/com/mineinabyss/geary/papermc/tracking/items/systems/LoginListener.kt
@@ -11,15 +11,13 @@ import com.mineinabyss.geary.papermc.tracking.items.cache.PlayerItemCache
 import com.mineinabyss.geary.prefabs.entityOfOrNull
 import com.mineinabyss.idofront.nms.aliases.NMSItemStack
 import com.mineinabyss.idofront.nms.nbt.fastPDC
-import net.minecraft.world.item.Items
-import org.bukkit.Material
+import io.papermc.paper.persistence.PersistentDataContainerView
 import org.bukkit.event.EventHandler
 import org.bukkit.event.EventPriority
 import org.bukkit.event.Listener
 import org.bukkit.event.player.PlayerJoinEvent
 import org.bukkit.event.player.PlayerQuitEvent
 import org.bukkit.inventory.ItemStack
-import org.bukkit.persistence.PersistentDataContainer
 import java.util.*
 
 class LoginListener(
@@ -41,20 +39,20 @@ class LoginListener(
     companion object {
         context(Geary)
         fun readItemInfo(item: NMSItemStack): ItemInfo {
-            if (item.item == Items.AIR) return ItemInfo.NothingEncoded
+            if (item.isEmpty) return ItemInfo.NothingEncoded
             val pdc = item.fastPDC ?: return ItemInfo.NothingEncoded
             return readItemInfo(pdc)
         }
 
         context(Geary)
         fun readItemInfo(item: ItemStack): ItemInfo {
-            if (item.type == Material.AIR) return ItemInfo.NothingEncoded
-            val pdc = item.itemMeta.persistentDataContainer
+            if (item.isEmpty) return ItemInfo.NothingEncoded
+            val pdc = item.persistentDataContainer
             return readItemInfo(pdc)
         }
 
         context(Geary)
-        fun readItemInfo(pdc: PersistentDataContainer): ItemInfo {
+        fun readItemInfo(pdc: PersistentDataContainerView): ItemInfo {
             if (!pdc.hasComponentsEncoded) return ItemInfo.NothingEncoded
 
             val prefabKeys = pdc.decodePrefabs()

--- a/geary-papermc-tracking/src/main/kotlin/com/mineinabyss/geary/papermc/tracking/items/systems/PeriodicSaveSystem.kt
+++ b/geary-papermc-tracking/src/main/kotlin/com/mineinabyss/geary/papermc/tracking/items/systems/PeriodicSaveSystem.kt
@@ -4,7 +4,6 @@ import com.mineinabyss.geary.modules.Geary
 import com.mineinabyss.geary.papermc.datastore.encode
 import com.mineinabyss.geary.serialization.components.Persists
 import com.mineinabyss.geary.systems.query.Query
-import com.mineinabyss.idofront.items.editItemMeta
 import org.bukkit.inventory.ItemStack
 import kotlin.time.Duration.Companion.seconds
 
@@ -21,12 +20,12 @@ fun Geary.createPeriodicSaveSystem() = system(
 //            return
 //        }
 
-    q.item.editItemMeta {
+    q.item.editPersistentDataContainer { pdc ->
         q.persisting.forEach {
             val newHash = it.targetData.hashCode()
             if (newHash != it.data.hash) {
                 it.data.hash = newHash
-                persistentDataContainer.encode(it.targetData)
+                pdc.encode(it.targetData)
             }
         }
     }


### PR DESCRIPTION
We want to avoid using ItemMeta as much as possible due to this rebuilding the entire meta
We can also directly use read-only ItemStack#getPersistentDataContainer and the intender consumer-edit methods when we need to alter the PDC
This should speed up handling of components by only ever interfacing with what it needs to