### PR TITLE
feat: new listeners & inSlot condition, cooldown reappear

### DIFF
--- a/geary-papermc-features/src/main/kotlin/com/mineinabyss/geary/papermc/features/common/conditions/common/InSlotCondition.kt
+++ b/geary-papermc-features/src/main/kotlin/com/mineinabyss/geary/papermc/features/common/conditions/common/InSlotCondition.kt
@@ -1,0 +1,25 @@
+package com.mineinabyss.geary.papermc.features.common.conditions.common
+
+import com.mineinabyss.geary.actions.ActionGroupContext
+import com.mineinabyss.geary.actions.Condition
+import com.mineinabyss.geary.papermc.toEntityOrNull
+import com.mineinabyss.geary.papermc.tracking.items.inventory.toGeary
+import com.mineinabyss.geary.prefabs.PrefabKey
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import org.bukkit.entity.Player
+
+@Serializable
+@SerialName("geary:in_slot")
+class InSlotCondition(val slots: List<Int>, val item: PrefabKey) : Condition {
+    override fun ActionGroupContext.execute(): Boolean = with(entity!!.world){
+        val player = entity?.get<Player>()?: return false
+
+        var contains = false
+        for (slot in slots) {
+            val theItemInSlot = player.inventory.toGeary()?.get(slot)
+            contains = contains || theItemInSlot?.prefabs?.contains(item.toEntityOrNull()) == true
+        }
+        return contains
+    }
+}

--- a/geary-papermc-features/src/main/kotlin/com/mineinabyss/geary/papermc/features/common/event_bridge/items/ItemInteractBridge.kt
+++ b/geary-papermc-features/src/main/kotlin/com/mineinabyss/geary/papermc/features/common/event_bridge/items/ItemInteractBridge.kt
@@ -1,6 +1,7 @@
 package com.mineinabyss.geary.papermc.features.common.event_bridge.items
 
 import com.mineinabyss.geary.papermc.toGeary
+import com.mineinabyss.geary.papermc.tracking.items.inventory.GearyPlayerInventory
 import com.mineinabyss.geary.papermc.tracking.items.inventory.toGeary
 import com.mineinabyss.idofront.entities.leftClicked
 import com.mineinabyss.idofront.entities.rightClicked
@@ -14,6 +15,9 @@ import org.bukkit.event.Listener
 import org.bukkit.event.block.Action
 import org.bukkit.event.player.PlayerInteractEntityEvent
 import org.bukkit.event.player.PlayerInteractEvent
+import org.bukkit.event.player.PlayerItemHeldEvent
+import org.bukkit.event.player.PlayerSwapHandItemsEvent
+import org.bukkit.event.player.PlayerToggleSneakEvent
 
 @Serializable
 @SerialName("geary:item_interact")
@@ -24,14 +28,20 @@ class OnItemInteract
 class OnItemLeftClick
 
 @Serializable
+@SerialName("geary:item_left_click_sneak")
+class OnItemLeftClickSneak
+
+@Serializable
 @SerialName("geary:item_left_click_block")
 class OnItemLeftClickBlock
-
 
 @Serializable
 @SerialName("geary:item_right_click")
 class OnItemRightClick
 
+@Serializable
+@SerialName("geary:item_right_click_sneak")
+class OnItemRightClickSneak
 
 @Serializable
 @SerialName("geary:item_right_click_block")
@@ -40,6 +50,20 @@ class OnItemRightClickBlock
 @Serializable
 @SerialName("geary:item_right_click_entity")
 class OnItemRightClickEntity
+
+@Serializable
+@SerialName("geary:item_swap_in")
+class OnItemSwapIn
+
+@Serializable
+@SerialName("geary:item_swap_out")
+class OnItemSwapOut
+
+@Serializable
+@SerialName("geary:item_sneak")
+class OnItemSneak
+
+
 
 class ItemInteractBridge : Listener {
     private val rightClickCooldowns = Int2IntOpenHashMap()
@@ -50,24 +74,82 @@ class ItemInteractBridge : Listener {
         heldItem.emit<OnItemRightClickEntity>()
     }
 
+    private inline fun <reified E : Any>emitToAll(inventory: GearyPlayerInventory?) {
+        // Armor Slots
+        inventory?.itemInHelmet?.emit<E>()
+        inventory?.itemInChestplate?.emit<E>()
+        inventory?.itemInLeggings?.emit<E>()
+        inventory?.itemInBoots?.emit<E>()
+
+        // Passive Slots
+        inventory?.get(9)?.emit<E>()
+        inventory?.get(10)?.emit<E>()
+    }
 
     @EventHandler
     fun PlayerArmSwingEvent.onLeftClick() {
-        val heldItem = player.inventory.toGeary()?.get(hand) ?: return
-        heldItem.emit<OnItemLeftClick>()
+        val heldItem = player.inventory.toGeary()?.get(hand)
+        heldItem?.emit<OnItemLeftClick>()
+        emitToAll<OnItemLeftClick>(player.inventory.toGeary())
+        if (player.isSneaking) {
+            emitToAll<OnItemLeftClickSneak>(player.inventory.toGeary())
+            heldItem?.emit<OnItemLeftClick>()
+        }
     }
 
     @EventHandler
     fun PlayerInteractEvent.onClick() {
+        // Don't fire if item is used
         if (useItemInHand() == Event.Result.DENY) return
-        val heldItem = player.inventory.toGeary()?.get(hand ?: return) ?: return
+
+        val heldItem = hand?.let { player.inventory.toGeary()?.get(it) }
 
         // Right click gets fired twice, so we manually prevent two right-clicks within several ticks of each other.
+        heldItem?.emit<OnItemInteract>()
 
-        heldItem.emit<OnItemInteract>()
+        if (leftClicked) {
+            heldItem?.emit<OnItemLeftClickBlock>()
+            if (player.isSneaking) {
+                heldItem?.emit<OnItemLeftClickSneak>()
+            }
+        }
 
-        if (leftClicked) heldItem.emit<OnItemLeftClickBlock>()
-        if (rightClicked) heldItem.emit<OnItemRightClick>()
-        if (action == Action.RIGHT_CLICK_BLOCK) heldItem.emit<OnItemRightClickBlock>()
+        if (rightClicked) {
+            heldItem?.emit<OnItemRightClick>()
+            emitToAll<OnItemRightClick>(player.inventory.toGeary())
+            if (player.isSneaking) {
+                heldItem?.emit<OnItemRightClickSneak>()
+                emitToAll<OnItemRightClickSneak>(player.inventory.toGeary())
+            }
+        }
+        if (action == Action.RIGHT_CLICK_BLOCK) heldItem?.emit<OnItemRightClickBlock>()
+    }
+
+    @EventHandler
+    fun PlayerItemHeldEvent.onItemSwap() {
+        val inventory = player.inventory.toGeary()
+        inventory?.get(newSlot)?.emit<OnItemSwapIn>()
+        inventory?.get(previousSlot)?.emit<OnItemSwapOut>()
+    }
+
+    @EventHandler
+    fun PlayerSwapHandItemsEvent.onItemSwap() {
+        val inventory = player.inventory.toGeary()
+        val mainHand = inventory?.itemInMainHand
+        val offHand = inventory?.itemInOffhand
+
+        // Emit both swaps for the items
+
+        mainHand?.emit<OnItemSwapIn>()
+        mainHand?.emit<OnItemSwapOut>()
+        offHand?.emit<OnItemSwapIn>()
+        offHand?.emit<OnItemSwapOut>()
+    }
+
+    @EventHandler
+    fun PlayerToggleSneakEvent.onItemSneak() {
+        if (!player.isSneaking) {
+            emitToAll<OnItemSneak>(player.inventory.toGeary())
+        }
     }
 }


### PR DESCRIPTION
## Adds the following observable events:

- itemLeftClickSneak: sneak + left click
- itemRightClickSneak: sneak + right click
- itemSwapIn: switch into item or swap hands
- itemSwapOut: switch out of active item or swap hands
- itemSneak: crouch while item is equipped

This allows different actions to run on right click and on sneak+right click, for example.

## Adds the inSlot condition:

For example:

- ensure: inSlot: slots: [9, 10, 38] - passive slots + chestplate slot item: mineinabyss:test_passive_1 - should usually be the same item but not required to be

Finally, several new slots will receive events.
These are the 4 equipment slots: helmet, chestplate, leggings, and boots, as well as slots 9 and 10 (which are the 2 top-left-most slots). The active hand slot will not receive the itemSneak event.

## Reshows cooldowns when abilities are reactivated.
This snuck in, guess it should probably be a separate PR