### PR TITLE
Feat: item attribute system

### DIFF
--- a/geary-papermc-features/src/main/kotlin/com/mineinabyss/geary/papermc/features/items/attributes/CustomAttributes.kt
+++ b/geary-papermc-features/src/main/kotlin/com/mineinabyss/geary/papermc/features/items/attributes/CustomAttributes.kt
@@ -1,0 +1,44 @@
+package com.mineinabyss.geary.papermc.features.items.attributes
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+@SerialName("geary:custom_attributes")
+data class CustomAttributes(
+    val attributes: Map<String, AttributeValue> = emptyMap()
+) {
+//    // Helper methods for easy access
+//    fun getInt(key: String): Int? = (attributes[key] as? AttributeValue.IntValue)?.value
+//    fun getDouble(key: String): Double? = (attributes[key] as? AttributeValue.DoubleValue)?.value
+//    fun getString(key: String): String? = (attributes[key] as? AttributeValue.StringValue)?.value
+//    fun getBoolean(key: String): Boolean? = (attributes[key] as? AttributeValue.BooleanValue)?.value
+//
+//    fun setInt(key: String, value: Int): CustomAttributes =
+//        copy(attributes = attributes + (key to AttributeValue.IntValue(value)))
+//    fun setDouble(key: String, value: Double): CustomAttributes =
+//        copy(attributes = attributes + (key to AttributeValue.DoubleValue(value)))
+//    fun setString(key: String, value: String): CustomAttributes =
+//        copy(attributes = attributes + (key to AttributeValue.StringValue(value)))
+//    fun setBoolean(key: String, value: Boolean): CustomAttributes =
+//        copy(attributes = attributes + (key to AttributeValue.BooleanValue(value)))
+}
+
+@Serializable
+sealed class AttributeValue {
+    @Serializable
+    @SerialName("int")
+    data class IntValue(val value: Int) : AttributeValue()
+
+    @Serializable
+    @SerialName("double")
+    data class DoubleValue(val value: Double) : AttributeValue()
+
+    @Serializable
+    @SerialName("string")
+    data class StringValue(val value: String) : AttributeValue()
+
+    @Serializable
+    @SerialName("boolean")
+    data class BooleanValue(val value: Boolean) : AttributeValue()
+}

--- a/geary-papermc-features/src/main/kotlin/com/mineinabyss/geary/papermc/features/items/attributes/CustomAttributes.kt
+++ b/geary-papermc-features/src/main/kotlin/com/mineinabyss/geary/papermc/features/items/attributes/CustomAttributes.kt
@@ -7,22 +7,7 @@ import kotlinx.serialization.Serializable
 @SerialName("geary:custom_attributes")
 data class CustomAttributes(
     val attributes: Map<String, AttributeValue> = emptyMap()
-) {
-//    // Helper methods for easy access
-//    fun getInt(key: String): Int? = (attributes[key] as? AttributeValue.IntValue)?.value
-//    fun getDouble(key: String): Double? = (attributes[key] as? AttributeValue.DoubleValue)?.value
-//    fun getString(key: String): String? = (attributes[key] as? AttributeValue.StringValue)?.value
-//    fun getBoolean(key: String): Boolean? = (attributes[key] as? AttributeValue.BooleanValue)?.value
-//
-//    fun setInt(key: String, value: Int): CustomAttributes =
-//        copy(attributes = attributes + (key to AttributeValue.IntValue(value)))
-//    fun setDouble(key: String, value: Double): CustomAttributes =
-//        copy(attributes = attributes + (key to AttributeValue.DoubleValue(value)))
-//    fun setString(key: String, value: String): CustomAttributes =
-//        copy(attributes = attributes + (key to AttributeValue.StringValue(value)))
-//    fun setBoolean(key: String, value: Boolean): CustomAttributes =
-//        copy(attributes = attributes + (key to AttributeValue.BooleanValue(value)))
-}
+)
 
 @Serializable
 sealed class AttributeValue {

--- a/geary-papermc-features/src/main/kotlin/com/mineinabyss/geary/papermc/features/items/attributes/CustomAttributesConditions.kt
+++ b/geary-papermc-features/src/main/kotlin/com/mineinabyss/geary/papermc/features/items/attributes/CustomAttributesConditions.kt
@@ -1,0 +1,65 @@
+package com.mineinabyss.geary.papermc.features.items.attributes
+
+import com.mineinabyss.geary.actions.ActionGroupContext
+import com.mineinabyss.geary.actions.Condition
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.Transient
+
+@Serializable
+@SerialName("geary:attribute_condition")
+class AttributeCondition(
+    val name: String,
+    val comparison: AttributeComparison = AttributeComparison.GREATER_THAN,
+    val value: AttributeValue
+) : Condition {
+    @Transient
+    private var lastComp: Boolean = false
+
+    override fun ActionGroupContext.execute(): Boolean {
+        val attributes = entity?.get<CustomAttributes>() ?: return false
+        val currentValue = attributes.attributes[name] ?: return false
+
+
+        val result = when (comparison) {
+            AttributeComparison.EQUALS -> {
+                currentValue == value
+            }
+            AttributeComparison.GREATER_THAN -> {
+                if (currentValue is AttributeValue.IntValue && value is AttributeValue.IntValue) {
+                    currentValue.value > value.value
+                } else if (currentValue is AttributeValue.DoubleValue && value is AttributeValue.DoubleValue) {
+                    currentValue.value > value.value
+                } else {
+                    false
+                }
+            }
+            AttributeComparison.LESS_THAN -> {
+                if (currentValue is AttributeValue.IntValue && value is AttributeValue.IntValue) {
+                    currentValue.value < value.value
+                } else if (currentValue is AttributeValue.DoubleValue && value is AttributeValue.DoubleValue) {
+                    currentValue.value < value.value
+                } else {
+                    false
+                }
+            }
+        }
+
+        if (result) {
+            lastComp = true
+            return true
+        }
+
+        if (lastComp) {
+            lastComp = false
+            return true
+        }
+
+        return false
+    }
+}
+
+@Serializable
+enum class AttributeComparison {
+    EQUALS, GREATER_THAN, LESS_THAN
+}

--- a/geary-papermc-features/src/main/kotlin/com/mineinabyss/geary/papermc/features/items/attributes/CustomAttributesConditions.kt
+++ b/geary-papermc-features/src/main/kotlin/com/mineinabyss/geary/papermc/features/items/attributes/CustomAttributesConditions.kt
@@ -25,6 +25,7 @@ class AttributeCondition(
             AttributeComparison.EQUALS -> {
                 currentValue == value
             }
+
             AttributeComparison.GREATER_THAN -> {
                 if (currentValue is AttributeValue.IntValue && value is AttributeValue.IntValue) {
                     currentValue.value > value.value
@@ -34,6 +35,7 @@ class AttributeCondition(
                     false
                 }
             }
+
             AttributeComparison.LESS_THAN -> {
                 if (currentValue is AttributeValue.IntValue && value is AttributeValue.IntValue) {
                     currentValue.value < value.value

--- a/geary-papermc-features/src/main/kotlin/com/mineinabyss/geary/papermc/features/items/attributes/CustomAttributesConditions.kt
+++ b/geary-papermc-features/src/main/kotlin/com/mineinabyss/geary/papermc/features/items/attributes/CustomAttributesConditions.kt
@@ -47,6 +47,11 @@ class AttributeCondition(
             }
         }
 
+        /*
+        Bandaid fix to account for the fact that conditions are executed twice.
+        This allows to prevent the "onFail" block from being executed in case
+        the condition succeeds the first time.
+         */
         if (result) {
             lastComp = true
             return true

--- a/geary-papermc-features/src/main/kotlin/com/mineinabyss/geary/papermc/features/items/attributes/ModifyCustomAttributes.kt
+++ b/geary-papermc-features/src/main/kotlin/com/mineinabyss/geary/papermc/features/items/attributes/ModifyCustomAttributes.kt
@@ -6,21 +6,6 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-@SerialName("geary:set_attribute")
-class SetAttributeAction(
-    val name: String,
-    val value: AttributeValue
-) : Action {
-    override fun ActionGroupContext.execute() {
-        val current = entity?.get<CustomAttributes>() ?: CustomAttributes()
-        val updated = current.copy(
-            attributes = current.attributes + (name to value)
-        )
-        entity?.set(updated)
-    }
-}
-
-@Serializable
 @SerialName("geary:modify_attribute")
 class ModifyAttributeAction(
     val name: String,
@@ -31,7 +16,6 @@ class ModifyAttributeAction(
         val current = entity?.get<CustomAttributes>() ?: CustomAttributes()
         val currentValue = current.attributes[name]
 
-        println("value is ${value}")
         val newValue = when (operation) {
             AttributeOperation.ADD -> when {
                 currentValue is AttributeValue.IntValue && value is AttributeValue.IntValue ->

--- a/geary-papermc-features/src/main/kotlin/com/mineinabyss/geary/papermc/features/items/attributes/ModifyCustomAttributes.kt
+++ b/geary-papermc-features/src/main/kotlin/com/mineinabyss/geary/papermc/features/items/attributes/ModifyCustomAttributes.kt
@@ -1,0 +1,63 @@
+package com.mineinabyss.geary.papermc.features.items.attributes
+
+import com.mineinabyss.geary.actions.Action
+import com.mineinabyss.geary.actions.ActionGroupContext
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+@SerialName("geary:set_attribute")
+class SetAttributeAction(
+    val name: String,
+    val value: AttributeValue
+) : Action {
+    override fun ActionGroupContext.execute() {
+        val current = entity?.get<CustomAttributes>() ?: CustomAttributes()
+        val updated = current.copy(
+            attributes = current.attributes + (name to value)
+        )
+        entity?.set(updated)
+    }
+}
+
+@Serializable
+@SerialName("geary:modify_attribute")
+class ModifyAttributeAction(
+    val name: String,
+    val operation: AttributeOperation,
+    val value: AttributeValue
+) : Action {
+    override fun ActionGroupContext.execute() {
+        val current = entity?.get<CustomAttributes>() ?: CustomAttributes()
+        val currentValue = current.attributes[name]
+
+        println("value is ${value}")
+        val newValue = when (operation) {
+            AttributeOperation.ADD -> when {
+                currentValue is AttributeValue.IntValue && value is AttributeValue.IntValue ->
+                    AttributeValue.IntValue(currentValue.value + value.value)
+                currentValue is AttributeValue.DoubleValue && value is AttributeValue.DoubleValue ->
+                    AttributeValue.DoubleValue(currentValue.value + value.value)
+                else -> value
+            }
+            AttributeOperation.MULTIPLY -> when {
+                currentValue is AttributeValue.IntValue && value is AttributeValue.IntValue ->
+                    AttributeValue.IntValue(currentValue.value * value.value)
+                currentValue is AttributeValue.DoubleValue && value is AttributeValue.DoubleValue ->
+                    AttributeValue.DoubleValue(currentValue.value * value.value)
+                else -> value
+            }
+            AttributeOperation.SET -> value
+        }
+
+        val updated = current.copy(
+            attributes = current.attributes + (name to newValue)
+        )
+        entity?.set(updated)
+    }
+}
+
+@Serializable
+enum class AttributeOperation {
+    SET, ADD, MULTIPLY
+}

--- a/geary-papermc-features/src/main/kotlin/com/mineinabyss/geary/papermc/features/items/attributes/ModifyCustomAttributes.kt
+++ b/geary-papermc-features/src/main/kotlin/com/mineinabyss/geary/papermc/features/items/attributes/ModifyCustomAttributes.kt
@@ -36,17 +36,23 @@ class ModifyAttributeAction(
             AttributeOperation.ADD -> when {
                 currentValue is AttributeValue.IntValue && value is AttributeValue.IntValue ->
                     AttributeValue.IntValue(currentValue.value + value.value)
+
                 currentValue is AttributeValue.DoubleValue && value is AttributeValue.DoubleValue ->
                     AttributeValue.DoubleValue(currentValue.value + value.value)
+
                 else -> value
             }
+
             AttributeOperation.MULTIPLY -> when {
                 currentValue is AttributeValue.IntValue && value is AttributeValue.IntValue ->
                     AttributeValue.IntValue(currentValue.value * value.value)
+
                 currentValue is AttributeValue.DoubleValue && value is AttributeValue.DoubleValue ->
                     AttributeValue.DoubleValue(currentValue.value * value.value)
+
                 else -> value
             }
+
             AttributeOperation.SET -> value
         }
 


### PR DESCRIPTION
An early attempt at making items support custom variables. 

To add an attribute to an item: 
```
geary:custom_attributes:
  attributes:
    [name]:
      type: [int, double, string, boolean]
      value: [default value]
```

To modify an attribute: 
```
geary:modify_attribute:
      name: "[name]"
      operation: [SET, ADD, MULTIPLY]
      value:
        type: [int, double, string, boolean]
        value: [value]
```

To check for an attribute: 
```
geary:attribute_condition:
        name: "[name]"
        comparison: [GREATER_THAN, LESS_THAN, EQUALS]
        value:
          type: [int, double, string, boolean]
          value: [value]
```

Blaze reap rewritten using this system for example : 
```
set.item:
  type: minecraft:netherite_pickaxe
  itemModel: mineinabyss:blaze_reap
  itemName: <#617B94><b>Blaze Reap
  lore:
  - ':layer_4: Grade I Relic'
  - <#C6CC8A>Contains <white>Everlasting Gunpowder<#C6CC8A>,
  - <#C6CC8A>which causes ongoing explosions
  - <#C6CC8A>on whatever it is struck on.
  - <#948E61><i>Used to create powerful explosions.
  enchantments:
    enchantments:
      - enchant: minecraft:fortune
        level: 3
      - enchant: minecraft:efficiency
        level: 5
  enchantable: 0
  unbreakable: {}
geary:custom_attributes:
  attributes:
    charge_stacks:
      type: int
      value: 0
observe:
  itemLeftClick:
  - ensure: 
      geary:attribute_condition:
        name: "charge_stacks"
        comparison: GREATER_THAN
        value:
          type: int
          value: 4
    onFail:
    - become: parent
    - sendActionBar:
        text: <#617B94>Not Primed, charge more!
  - cooldown:
      id: BlazeReap
      length: 10s
      display: <#617B94>Blaze Reap
  - geary:modify_attribute:
      name: "charge_stacks"
      operation: SET
      value:
        type: int
        value: 0
  - become: parent
  - sendActionBar:
      text: <#617B94>skill trigger
  - playSound:
      sound: entity.generic.explode
      volume: 1.0
      pitch: 0.8
  
  itemRightClick:
  - ensure:
      geary:attribute_condition:
        name: "charge_stacks"
        comparison: LESS_THAN
        value:
          type: int
          value: 5
    onFail:
    - become: parent
    - sendActionBar:
        text: <#617B94>Already fully charged!
  - cooldown:
      id: Primer
      length: 1s
      display: <#617B94>Primer
  - geary:modify_attribute:
      name: "charge_stacks"
      operation: ADD
      value:
        type: int
        value: 1
  - become: parent
  - sendActionBar:
      text: <#617B94>Charging...
  - playSound:
      sound: block.beacon.power_select
      volume: 0.5
      pitch: 1.2
resourcepack:
  model: mineinabyss:item/relics/blaze_reap
```